### PR TITLE
feat: 🎸 upgrade gatekeeper to latest helm release and add a values file

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.x
+          terraform_version: 1.2.5
           terraform_wrapper: false
 
       - name: Run tf Tests
@@ -21,3 +21,4 @@ jobs:
         run: |
           terraform init
           terraform validate
+

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 Kubernetes native security policy enforcement, an upgrade of https://github.com/ministryofjustice/cloud-platform-terraform-opa
 
-## Usage
+Kubernetes allows decoupling policy decisions from the API server by means of admission controller webhooks to intercept admission requests before they are persisted as objects in Kubernetes. Gatekeeper is a customizable admission webhook for Kubernetes that enforces policies executed by the Open Policy Agent (OPA), a policy engine for Cloud Native environments hosted by CNCF.
 
+## Usage
 
 See the example/ subdir for invocation syntax
 

--- a/constraints.tf
+++ b/constraints.tf
@@ -5,7 +5,7 @@ resource "kubectl_manifest" "unique-ingress-template" {
   depends_on = [helm_release.gatekeeper]
 
   yaml_body = <<YAML
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   name: k8suniqueingresshost
@@ -64,7 +64,7 @@ resource "kubectl_manifest" "ingress-default-modsec-template" {
   depends_on = [helm_release.gatekeeper]
 
   yaml_body = <<YAML
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   name: k8sdenydefaultmodsec
@@ -180,15 +180,12 @@ apiVersion: config.gatekeeper.sh/v1alpha1
 kind: Config
 metadata:
   name: config
-  namespace: "gatekeeper"
+  namespace: "gatekeeper-system"
 spec:
   sync:
     syncOnly:
-      - group: "extensions"
-        version: "v1beta1"
-        kind: "Ingress"
       - group: "networking.k8s.io"
-        version: "v1beta1"
+        version: "v1"
         kind: "Ingress"
       - group: ""
         version: "v1"
@@ -201,3 +198,4 @@ spec:
         kind: "Service"
 YAML
 }
+

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,8 @@
 module "gatekeeper" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=0.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.1.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
   enable_invalid_hostname_policy = terraform.workspace == local.live_workspace ? false : true
-  define_constraints = true
+  define_constraints             = true
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_providers {  
+  required_providers {
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,0 +1,5 @@
+constraintViolationsLimit: ${constraint_violations_max_to_display}
+auditFromCache: ${audit_from_cache}
+postInstall:
+  labelNamespace:
+    enabled: ${post_install_label_namespace}

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
   required_providers {
     kubectl = {
       source  = "gavinbunney/kubectl"


### PR DESCRIPTION
This PR updates the gatekeeper module, the idea is to add gatekeeper into our cluster but have it not affect existing policies, basically, it's there but not doing anything. Then we can migrate and test each policy from opa to gatekeeper one policy at a time.