### PR TITLE
Migrate service type policy

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -22,3 +22,17 @@ jobs:
           terraform init
           terraform validate
 
+      - name: Run Gatekeeper Tests
+        working-directory: test/suite
+        run: |
+          # install gator via brew
+          curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh
+          test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)"
+          test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          test -r ~/.bash_profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bash_profile
+          echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.profile
+
+          brew install gator
+
+          gator verify ./...
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,29 @@ CAVEATS:
  - deleting a ConstraintTemplate that still has Constraints breaks things badly; only deleting the CRDs (which in turn removes all the constraints) unblocks again
  - no colons (:) in the description field
 
+## Testing
+
+gatekeeper provides a neat [cli tool](https://open-policy-agent.github.io/gatekeeper/website/docs/gator/) for testing. Once installed you can run the following command to verify the test suite has the expected violations:
+
+```sh
+gator verify test/suite/...
+```
+
+add new tests test data goes under their own dir `test/suite/samples/test_suite_name/` and the test suite file can be found in `test/suite/test_suite_name.yaml`, see diagram below:
+
+```
+test/suite
+├── samples/
+│   └── test_suite_name/
+│       ├── case_description_1/
+│       │   ├── case.yaml
+│       │   └── inventory.yaml
+│       └── case_description_2
+│           ├── case.yaml
+│           └── inventory.yaml
+└── test_suite_name.yaml
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/constraints.tf
+++ b/constraints.tf
@@ -5,134 +5,138 @@ resource "kubectl_manifest" "service-type-template" {
   yaml_body = file("${path.module}/resources/constraint_templates/service_type.yaml")
 }
 
+locals {
+  service_type_constraint = merge(yamldecode(file("${path.module}/resources/constraints/service_type.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.service_type ? "dryrun" : "deny" } })
+}
+
 resource "kubectl_manifest" "service-type-constraint" {
   depends_on = [kubectl_manifest.service-type-template]
 
-  yaml_body = file("${path.module}/resources/constraints/service_type.yaml")
+  yaml_body = yamlencode(local.service_type_constraint)
 }
 
-resource "kubectl_manifest" "unique-ingress-template" {
-  count      = var.define_constraints == true ? 1 : 0
-  depends_on = [helm_release.gatekeeper]
+# resource "kubectl_manifest" "unique-ingress-template" {
+#   count      = var.define_constraints == true ? 1 : 0
+#   depends_on = [helm_release.gatekeeper]
 
-  yaml_body = <<YAML
-apiVersion: templates.gatekeeper.sh/v1
-kind: ConstraintTemplate
-metadata:
-  name: k8suniqueingresshost
-  annotations:
-    description: Requires all Ingress hosts to be unique, unless they share a namespace.
-spec:
-  crd:
-    spec:
-      names:
-        kind: k8suniqueingresshost
-  targets:
-    - target: admission.k8s.gatekeeper.sh
-      rego: |
-        package k8suniqueingresshost
-        identical(obj, review) {
-          obj.metadata.namespace == review.object.metadata.namespace
-          obj.metadata.name == review.object.metadata.name
-        }
-        same_namespace(obj, review) {
-          obj.metadata.namespace == review.object.metadata.namespace
-        }
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "Ingress"
-          re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
-          host := input.review.object.spec.rules[_].host
-          other := data.inventory.namespace[ns][otherapiversion]["Ingress"][name]
-          re_match("^(extensions|networking.k8s.io)/.+$", otherapiversion)
-          other.spec.rules[_].host == host
-          namespace := other.metadata.namespace
-          not identical(other, input.review)
-          not same_namespace(other, input.review)
-          msg := sprintf("ingress host conflicts with an existing ingress <%v> in namespace <%v>", [host, namespace])
-        }
-YAML
-}
+#   yaml_body = <<YAML
+# apiVersion: templates.gatekeeper.sh/v1
+# kind: ConstraintTemplate
+# metadata:
+#   name: k8suniqueingresshost
+#   annotations:
+#     description: Requires all Ingress hosts to be unique, unless they share a namespace.
+# spec:
+#   crd:
+#     spec:
+#       names:
+#         kind: k8suniqueingresshost
+#   targets:
+#     - target: admission.k8s.gatekeeper.sh
+#       rego: |
+#         package k8suniqueingresshost
+#         identical(obj, review) {
+#           obj.metadata.namespace == review.object.metadata.namespace
+#           obj.metadata.name == review.object.metadata.name
+#         }
+#         same_namespace(obj, review) {
+#           obj.metadata.namespace == review.object.metadata.namespace
+#         }
+#         violation[{"msg": msg}] {
+#           input.review.kind.kind == "Ingress"
+#           re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
+#           host := input.review.object.spec.rules[_].host
+#           other := data.inventory.namespace[ns][otherapiversion]["Ingress"][name]
+#           re_match("^(extensions|networking.k8s.io)/.+$", otherapiversion)
+#           other.spec.rules[_].host == host
+#           namespace := other.metadata.namespace
+#           not identical(other, input.review)
+#           not same_namespace(other, input.review)
+#           msg := sprintf("ingress host conflicts with an existing ingress <%v> in namespace <%v>", [host, namespace])
+#         }
+# YAML
+# }
 
-resource "kubectl_manifest" "unique-ingress-constraint" {
-  count      = var.define_constraints == true ? 1 : 0
-  depends_on = [kubectl_manifest.unique-ingress-template]
+# resource "kubectl_manifest" "unique-ingress-constraint" {
+#   count      = var.define_constraints == true ? 1 : 0
+#   depends_on = [kubectl_manifest.unique-ingress-template]
 
-  yaml_body = <<YAML
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: k8suniqueingresshost
-metadata:
-  name: k8suniqueingresshost
-spec:
-  match:
-    kinds:
-      - apiGroups: ["extensions", "networking.k8s.io"]
-        kinds: ["Ingress"]
-YAML
-}
+#   yaml_body = <<YAML
+# apiVersion: constraints.gatekeeper.sh/v1beta1
+# kind: k8suniqueingresshost
+# metadata:
+#   name: k8suniqueingresshost
+# spec:
+#   match:
+#     kinds:
+#       - apiGroups: ["extensions", "networking.k8s.io"]
+#         kinds: ["Ingress"]
+# YAML
+# }
 
-resource "kubectl_manifest" "ingress-default-modsec-template" {
-  count      = var.define_constraints == true ? 1 : 0
-  depends_on = [helm_release.gatekeeper]
+# resource "kubectl_manifest" "ingress-default-modsec-template" {
+#   count      = var.define_constraints == true ? 1 : 0
+#   depends_on = [helm_release.gatekeeper]
 
-  yaml_body = <<YAML
-apiVersion: templates.gatekeeper.sh/v1
-kind: ConstraintTemplate
-metadata:
-  name: k8sdenydefaultmodsec
-  annotations:
-    description: This policy denies ingresses using default ingress-controller if they try to enable modsecurity.
-spec:
-  crd:
-    spec:
-      names:
-        kind: k8sdenydefaultmodsec
-  targets:
-    - target: admission.k8s.gatekeeper.sh
-      rego: |
-        package k8sdenydefaultmodsec
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "Ingress"
-          input.review.object.metadata.annotations["kubernetes.io/ingress.class"] == "nginx"
-          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] == "true"
-          msg := "mod-security is not allowed for default ingress"
-        }
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "Ingress"
-          not input.review.object.metadata.annotations["kubernetes.io/ingress.class"]
-          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] == "true"
-          msg := "mod-security is not allowed for default ingress"
-        }
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "Ingress"
-          input.review.object.metadata.annotations["kubernetes.io/ingress.class"] == "nginx"
-          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
-          msg := "modsecurity-snippet is not allowed for default ingress"
-        }
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "Ingress"
-          not input.review.object.metadata.annotations["kubernetes.io/ingress.class"]
-          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
-          msg := "modsecurity-snippet is not allowed for default ingress"
-        }
-YAML
-}
+#   yaml_body = <<YAML
+# apiVersion: templates.gatekeeper.sh/v1
+# kind: ConstraintTemplate
+# metadata:
+#   name: k8sdenydefaultmodsec
+#   annotations:
+#     description: This policy denies ingresses using default ingress-controller if they try to enable modsecurity.
+# spec:
+#   crd:
+#     spec:
+#       names:
+#         kind: k8sdenydefaultmodsec
+#   targets:
+#     - target: admission.k8s.gatekeeper.sh
+#       rego: |
+#         package k8sdenydefaultmodsec
+#         violation[{"msg": msg}] {
+#           input.review.kind.kind == "Ingress"
+#           input.review.object.metadata.annotations["kubernetes.io/ingress.class"] == "nginx"
+#           input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] == "true"
+#           msg := "mod-security is not allowed for default ingress"
+#         }
+#         violation[{"msg": msg}] {
+#           input.review.kind.kind == "Ingress"
+#           not input.review.object.metadata.annotations["kubernetes.io/ingress.class"]
+#           input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] == "true"
+#           msg := "mod-security is not allowed for default ingress"
+#         }
+#         violation[{"msg": msg}] {
+#           input.review.kind.kind == "Ingress"
+#           input.review.object.metadata.annotations["kubernetes.io/ingress.class"] == "nginx"
+#           input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
+#           msg := "modsecurity-snippet is not allowed for default ingress"
+#         }
+#         violation[{"msg": msg}] {
+#           input.review.kind.kind == "Ingress"
+#           not input.review.object.metadata.annotations["kubernetes.io/ingress.class"]
+#           input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
+#           msg := "modsecurity-snippet is not allowed for default ingress"
+#         }
+# YAML
+# }
 
-resource "kubectl_manifest" "ingress-default-modsec-constraint" {
-  count      = var.define_constraints == true ? 1 : 0
-  depends_on = [kubectl_manifest.ingress-default-modsec-template]
+# resource "kubectl_manifest" "ingress-default-modsec-constraint" {
+#   count      = var.define_constraints == true ? 1 : 0
+#   depends_on = [kubectl_manifest.ingress-default-modsec-template]
 
-  yaml_body = <<YAML
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: k8sdenydefaultmodsec
-metadata:
-  name: k8sdenydefaultmodsec
-spec:
-  match:
-    kinds:
-      - apiGroups: ["extensions", "networking.k8s.io"]
-        kinds: ["Ingress"]
-YAML
-}
+#   yaml_body = <<YAML
+# apiVersion: constraints.gatekeeper.sh/v1beta1
+# kind: k8sdenydefaultmodsec
+# metadata:
+#   name: k8sdenydefaultmodsec
+# spec:
+#   match:
+#     kinds:
+#       - apiGroups: ["extensions", "networking.k8s.io"]
+#         kinds: ["Ingress"]
+# YAML
+# }
 
 /* This dosn't work, to be fixed in next PR
 resource "kubectl_manifest" "pod-tolerations-template" {

--- a/constraints.tf
+++ b/constraints.tf
@@ -1,7 +1,18 @@
 # remember any kind used by a constraint template must also be added to the sync config at the end of this file
+resource "kubectl_manifest" "service-type-template" {
+  depends_on = [helm_release.gatekeeper]
+
+  yaml_body = file("${path.module}/resources/constraint_templates/service_type.yaml")
+}
+
+resource "kubectl_manifest" "service-type-constraint" {
+  depends_on = [kubectl_manifest.service-type-template]
+
+  yaml_body = file("${path.module}/resources/constraints/service_type.yaml")
+}
 
 resource "kubectl_manifest" "unique-ingress-template" {
-  count = var.define_constraints == true ? 1 : 0
+  count      = var.define_constraints == true ? 1 : 0
   depends_on = [helm_release.gatekeeper]
 
   yaml_body = <<YAML
@@ -43,7 +54,7 @@ YAML
 }
 
 resource "kubectl_manifest" "unique-ingress-constraint" {
-  count = var.define_constraints == true ? 1 : 0
+  count      = var.define_constraints == true ? 1 : 0
   depends_on = [kubectl_manifest.unique-ingress-template]
 
   yaml_body = <<YAML
@@ -60,7 +71,7 @@ YAML
 }
 
 resource "kubectl_manifest" "ingress-default-modsec-template" {
-  count = var.define_constraints == true ? 1 : 0
+  count      = var.define_constraints == true ? 1 : 0
   depends_on = [helm_release.gatekeeper]
 
   yaml_body = <<YAML
@@ -107,7 +118,7 @@ YAML
 }
 
 resource "kubectl_manifest" "ingress-default-modsec-constraint" {
-  count = var.define_constraints == true ? 1 : 0
+  count      = var.define_constraints == true ? 1 : 0
   depends_on = [kubectl_manifest.ingress-default-modsec-template]
 
   yaml_body = <<YAML

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -4,7 +4,7 @@ module "gatekeeper" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
   enable_invalid_hostname_policy       = terraform.workspace == local.live_workspace ? false : true
-  define_constraints                   = true
+  dryrun_map                           = { service_type = true }
   constraint_violations_max_to_display = 25
   is_production                        = terraform.workspace == local.production_workspace ? "true" : "false"
   environment_name                     = terraform.workspace == local.production_workspace ? "production" : "development"

--- a/resources/constraint_templates/service_type.yaml
+++ b/resources/constraint_templates/service_type.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sservicetypeloadbalancer
   annotations:
-    description: Requires all Services with load balancers to have the correct annotation.
+    description: Requires all Services with spec.type == "LoadBalancer" to have the correct annotation in associated namespace
 spec:
   crd:
     spec:

--- a/resources/constraint_templates/service_type.yaml
+++ b/resources/constraint_templates/service_type.yaml
@@ -1,0 +1,24 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sservicetypeloadbalancer
+  annotations:
+    description: Requires all Services with load balancers to have the correct annotation.
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8sservicetypeloadbalancer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sservicetypeloadbalancer
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Service"
+          input.review.object.spec.type == "LoadBalancer"
+          not data.inventory.cluster["v1"].Namespace[input.review.object.metadata.namespace].metadata.annotations["cloud-platform.justice.gov.uk/can-use-loadbalancer-services"]
+
+          msg := sprintf("Service %v/%v is of type LoadBalancer and is not allowed. Please get in touch with us in #ask-cloud-platform", [input.review.object.metadata.namespace, input.review.object.metadata.name])
+        }
+

--- a/resources/constraints/service_type.yaml
+++ b/resources/constraints/service_type.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8sservicetypeloadbalancer
+metadata:
+  name: k8sservicetypeloadbalancer
+spec:
+  match:
+    kinds:
+      - kinds: ["Service"]
+

--- a/resources/constraints/service_type.yaml
+++ b/resources/constraints/service_type.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8sservicetypeloadbalancer
 spec:
   match:
+    excludedNamespaces: ["ingress-controllers"]
     kinds:
       - kinds: ["Service"]
 

--- a/test/suite/samples/service_type/allowed_annotation_key/case.yaml
+++ b/test/suite/samples/service_type/allowed_annotation_key/case.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service_type
+  namespace: starter-pack-0
+spec:
+  selector:
+    app.kubernetes.io/name: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+  type: LoadBalancer
+

--- a/test/suite/samples/service_type/allowed_annotation_key/inventory.yaml
+++ b/test/suite/samples/service_type/allowed_annotation_key/inventory.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/can-use-loadbalancer-services: "true"
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/samples/service_type/allowed_annotation_key_no_value/case.yaml
+++ b/test/suite/samples/service_type/allowed_annotation_key_no_value/case.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service_type
+  namespace: starter-pack-0
+spec:
+  selector:
+    app.kubernetes.io/name: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+  type: LoadBalancer

--- a/test/suite/samples/service_type/allowed_annotation_key_no_value/inventory.yaml
+++ b/test/suite/samples/service_type/allowed_annotation_key_no_value/inventory.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/can-use-loadbalancer-services: ""
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/samples/service_type/allowed_cluster_ip/case.yaml
+++ b/test/suite/samples/service_type/allowed_cluster_ip/case.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service_type
+  namespace: starter-pack-0
+spec:
+  selector:
+    app.kubernetes.io/name: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+  type: ClusterIP
+

--- a/test/suite/samples/service_type/allowed_cluster_ip/inventory.yaml
+++ b/test/suite/samples/service_type/allowed_cluster_ip/inventory.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/samples/service_type/disallowed_no_annotation_key/case.yaml
+++ b/test/suite/samples/service_type/disallowed_no_annotation_key/case.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service_type
+  namespace: starter-pack-0
+spec:
+  selector:
+    app.kubernetes.io/name: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+  type: LoadBalancer
+

--- a/test/suite/samples/service_type/disallowed_no_annotation_key/inventory.yaml
+++ b/test/suite/samples/service_type/disallowed_no_annotation_key/inventory.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/service_type.yaml
+++ b/test/suite/service_type.yaml
@@ -1,0 +1,31 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+- name: service_type
+  template: ../../resources/constraint_templates/service_type.yaml
+  constraint: ../../resources/constraints/service_type.yaml
+  cases:
+  - name: allowed-cluster-ip
+    inventory: 
+      - samples/service_type/allowed_cluster_ip/inventory.yaml
+    object: samples/service_type/allowed_cluster_ip/case.yaml
+    assertions:
+    - violations: no
+  - name: allowed-annotation-key-no-value
+    inventory:
+      - samples/service_type/allowed_annotation_key_no_value/inventory.yaml
+    object: samples/service_type/allowed_annotation_key_no_value/case.yaml
+    assertions:
+    - violations: no
+  - name: allowed-annotation-key
+    inventory:
+      - samples/service_type/allowed_annotation_key/inventory.yaml
+    object: samples/service_type/allowed_annotation_key/case.yaml
+    assertions:
+    - violations: no
+  - name: disallowed-no-annotation
+    inventory:
+      - samples/service_type/disallowed_no_annotation_key/inventory.yaml
+    object: samples/service_type/disallowed_no_annotation_key/case.yaml
+    assertions:
+    - violations: yes

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -8,7 +8,7 @@ module "gatekeeper" {
 
   cluster_domain_name                  = "gatekeeper.cloud-platform.service.justice.gov.uk"
   enable_invalid_hostname_policy       = false
-  define_constraints                   = true
+  dryrun_map                           = { service_type = true }
   constraint_violations_max_to_display = 25
   is_production                        = "false"
   environment_name                     = "development"

--- a/variables.tf
+++ b/variables.tf
@@ -8,12 +8,6 @@ variable "enable_invalid_hostname_policy" {
   type        = bool
 }
 
-variable "define_constraints" {
-  description = "if false, only the app is deployed, no constraints"
-  default     = true
-  type        = bool
-}
-
 variable "constraint_violations_max_to_display" {
   description = "the max number of violations to display per constraint"
   default     = 20
@@ -53,4 +47,11 @@ variable "audit_mem_limit" {
 variable "audit_mem_req" {
   description = "memory req for gatekeeper audit"
   type        = string
+}
+
+variable "dryrun_map" {
+  description = "run constraints in dryrun mode "
+  type = object({
+    service_type = bool
+  })
 }


### PR DESCRIPTION
For the services with type load balancer deny creation unless their namespace has "can-use-loadbalancer-services" annotation.

We will merge this into infra main with `dryrun` enabled, verify it is what we expect and then in a follow up PR disable the relevant OPA rule and turn off `dryrun` on gatekeeper.

This PR:

- creates constraint template
- creates constraint
- adds gatekeeper tests
- adds gatekeeper tests to github action

Note:
- ingress services (nginx & modsec) are in violation of this currently (they are of type LoadBalancer but their namespace does not have the "can-use-loadbalancer-services" annotation), to resolve this we have excluded the namespace from this constraint
