### PR TITLE
feat: 🎸 add pod toleration constraint

### DIFF
--- a/constraints.tf
+++ b/constraints.tf
@@ -1,14 +1,14 @@
 # remember any kind used by a constraint template must also be added to the sync config at the end of this file
 resource "kubectl_manifest" "constraint_templates" {
   depends_on = [helm_release.gatekeeper]
-  for_each = fileset("${path.module}/resources/constraint_templates/", "*")
-  
+  for_each   = fileset("${path.module}/resources/constraint_templates/", "*")
+
   yaml_body = file("${path.module}/resources/constraint_templates/${each.value}")
 }
 
 resource "kubectl_manifest" "constraints" {
   depends_on = [kubectl_manifest.constraint_templates]
-  for_each = local.constraint_map
+  for_each   = local.constraint_map
 
   yaml_body = yamlencode("${each.value}")
 }
@@ -161,25 +161,6 @@ spec:
           not input.review.kind.kind == "Pod"
           msg := "WIP"
         }
-YAML
-}
-*/
-
-/* This dosn't work, to be fixed in next PR 
-resource "kubectl_manifest" "pod-tolerations-constraint" {
-  count = var.define_constraints == true ? 1 : 0
-  depends_on = [kubectl_manifest.pod-tolerations-template]
-
-  yaml_body = <<YAML
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: k8spodtolerations
-metadata:
-  name: k8spodtolerations
-spec:
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
 YAML
 }
 */

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,7 +3,7 @@ module "gatekeeper" {
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
-  dryrun_map                           = { service_type = true, snippet_allowlist = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, pod_toleration = true }
   constraint_violations_max_to_display = 25
   is_production                        = terraform.workspace == local.production_workspace ? "true" : "false"
   environment_name                     = terraform.workspace == local.production_workspace ? "production" : "development"

--- a/resources/constraint_templates/pod_toleration.yaml
+++ b/resources/constraint_templates/pod_toleration.yaml
@@ -1,0 +1,29 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spodtoleration
+  annotations:
+    description: Prevent scheduling any workload on master node except for required system services namespaces which have the correct annotations
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8spodtoleration
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spodtoleration
+
+        violation[{"msg": msg}] {
+          toleration := input.review.object.spec.tolerations
+          not toleration["key"]
+          not data.inventory.cluster["v1"].Namespace[input.review.object.metadata.namespace].metadata.annotations["cloud-platform.justice.gov.uk/can-tolerate-master-taints"]
+          msg := sprintf("Pods %v/%v have tolerations. Pods with tolerations will not be scheduled. Please get in touch with us in #ask-cloud-platform", [input.review.object.metadata.name, input.review.object.metadata.namespace])
+        }
+
+        violation[{"msg": msg}] {
+          toleration := input.review.object.spec.tolerations
+          toleration["key"] == "node-role.kubernetes.io/master"
+          not data.inventory.cluster["v1"].Namespace[input.review.object.metadata.namespace].metadata.annotations["cloud-platform.justice.gov.uk/can-tolerate-master-taints"]
+          msg := sprintf("Pods %v/%v have tolerations. Pods with tolerations will not be scheduled. Please get in touch with us in #ask-cloud-platform", [input.review.object.metadata.name, input.review.object.metadata.namespace])
+        }

--- a/resources/constraints/pod_toleration.yaml
+++ b/resources/constraints/pod_toleration.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8spodtoleration
+metadata:
+  name: k8spodtoleration
+spec:
+  match:
+    kinds:
+      - kinds: ["Pod"]
+

--- a/test/suite/pod_toleration.yaml
+++ b/test/suite/pod_toleration.yaml
@@ -1,0 +1,50 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+- name: pod_toleration
+  template: ../../resources/constraint_templates/pod_toleration.yaml
+  constraint: ../../resources/constraints/pod_toleration.yaml
+  cases:
+    - name: allow-with-no-tolerations
+      inventory:
+       - samples/pod_toleration/allow_pod_no_tolerations/inventory.yaml
+      object: samples/pod_toleration/allow_pod_no_tolerations/case.yaml
+      assertions:
+      - violations: no
+    - name: allow-with-toleration-key-and-annotation
+      inventory: 
+       - samples/pod_toleration/allow_annotation/inventory.yaml
+      object: samples/pod_toleration/allow_annotation/case.yaml
+      assertions:
+      - violations: no
+    - name: allow-with-toleration-key-and-no-annotation
+      inventory: 
+       - samples/pod_toleration/allow_key_no_annotation/inventory.yaml
+      object: samples/pod_toleration/allow_key_no_annotation/case.yaml
+      assertions:
+      - violations: no
+    - name: deny-on-master-node-no-annotation
+      inventory: 
+       - samples/pod_toleration/deny_master_node_no_annotation/inventory.yaml
+      object: samples/pod_toleration/deny_master_node_no_annotation/case.yaml
+      assertions:
+      - violations: yes
+    - name: allow-on-master-node
+      inventory: 
+       - samples/pod_toleration/allow_master_node/inventory.yaml
+      object: samples/pod_toleration/allow_master_node/case.yaml
+      assertions:
+      - violations: no
+    - name: deny-with-invalid-key
+      inventory: 
+       - samples/pod_toleration/deny_invalid_key/inventory.yaml
+      object: samples/pod_toleration/deny_invalid_key/case.yaml
+      assertions:
+      - violations: yes
+    - name: deny-with-null-key
+      inventory: 
+       - samples/pod_toleration/deny_no_toleration_key/inventory.yaml
+      object: samples/pod_toleration/deny_no_toleration_key/case.yaml
+      assertions:
+      - violations: yes
+

--- a/test/suite/samples/pod_toleration/allow_annotation/case.yaml
+++ b/test/suite/samples/pod_toleration/allow_annotation/case.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+  namespace: starter-pack-0
+spec:
+  tolerations:
+    key: "foo"
+

--- a/test/suite/samples/pod_toleration/allow_annotation/inventory.yaml
+++ b/test/suite/samples/pod_toleration/allow_annotation/inventory.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+    cloud-platform.justice.gov.uk/can-tolerate-master-taints: "true"
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/samples/pod_toleration/allow_key_no_annotation/case.yaml
+++ b/test/suite/samples/pod_toleration/allow_key_no_annotation/case.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+  namespace: starter-pack-0
+spec:
+  tolerations:
+    key: "foo"
+

--- a/test/suite/samples/pod_toleration/allow_key_no_annotation/inventory.yaml
+++ b/test/suite/samples/pod_toleration/allow_key_no_annotation/inventory.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+
+

--- a/test/suite/samples/pod_toleration/allow_master_node/case.yaml
+++ b/test/suite/samples/pod_toleration/allow_master_node/case.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+  namespace: starter-pack-0
+spec:
+  tolerations:
+    key: "node-role.kubernetes.io/master"
+

--- a/test/suite/samples/pod_toleration/allow_master_node/inventory.yaml
+++ b/test/suite/samples/pod_toleration/allow_master_node/inventory.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+    cloud-platform.justice.gov.uk/can-tolerate-master-taints: "true"
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/samples/pod_toleration/allow_pod_no_tolerations/case.yaml
+++ b/test/suite/samples/pod_toleration/allow_pod_no_tolerations/case.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+  namespace: starter-pack-0
+

--- a/test/suite/samples/pod_toleration/allow_pod_no_tolerations/inventory.yaml
+++ b/test/suite/samples/pod_toleration/allow_pod_no_tolerations/inventory.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/samples/pod_toleration/deny_invalid_key/case.yaml
+++ b/test/suite/samples/pod_toleration/deny_invalid_key/case.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+  namespace: starter-pack-0
+spec:
+  tolerations:
+    key: false
+

--- a/test/suite/samples/pod_toleration/deny_invalid_key/inventory.yaml
+++ b/test/suite/samples/pod_toleration/deny_invalid_key/inventory.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/suite/samples/pod_toleration/deny_master_node_no_annotation/case.yaml
+++ b/test/suite/samples/pod_toleration/deny_master_node_no_annotation/case.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+  namespace: starter-pack-0
+spec:
+  tolerations:
+    key: "node-role.kubernetes.io/master"

--- a/test/suite/samples/pod_toleration/deny_master_node_no_annotation/inventory.yaml
+++ b/test/suite/samples/pod_toleration/deny_master_node_no_annotation/inventory.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+
+

--- a/test/suite/samples/pod_toleration/deny_no_toleration_key/case.yaml
+++ b/test/suite/samples/pod_toleration/deny_no_toleration_key/case.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+  namespace: starter-pack-0
+spec:
+  tolerations:
+    operator: "exists" 
+    effect: "NoSchedule"
+

--- a/test/suite/samples/pod_toleration/deny_no_toleration_key/inventory.yaml
+++ b/test/suite/samples/pod_toleration/deny_no_toleration_key/inventory.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cloud-platform.justice.gov.uk/application: Cloud Platform starter pack test app
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/owner: 'Cloud Platform: platforms@digital.justice.gov.uk'
+    cloud-platform.justice.gov.uk/source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  labels:
+    name: starter-pack-0
+  name: starter-pack-0
+

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -7,7 +7,7 @@ module "gatekeeper" {
   source = "../../"
 
   cluster_domain_name                  = "gatekeeper.cloud-platform.service.justice.gov.uk"
-  dryrun_map                           = { service_type = true, snippet_allowlist = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, pod_toleration = true }
   constraint_violations_max_to_display = 25
   is_production                        = "false"
   environment_name                     = "development"

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,8 @@ variable "audit_mem_req" {
 variable "dryrun_map" {
   description = "run constraints in dryrun mode "
   type = object({
-    service_type = bool
+    service_type      = bool
     snippet_allowlist = bool
+    pod_toleration    = bool
   })
 }


### PR DESCRIPTION
port pod toleration rules from opa to gatekeeper. In this PR:

- tweak rego logic (to select the toleration key correctly)
- combine pod toleration rules
- shored up unit testing, by porting the existing tests and adding more