### PR TITLE
Migrating modsec_snippet_nginx_class constraint and tests from OPA to Gatekeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Kubernetes allows decoupling policy decisions from the API server by means of ad
 3. Update the `constraint_map` in the local block in the `locals.tf` file
 4. Update the `dryrun_map` variable in the `variables.tf` files
 5. Update the `dryrun_map` variable in the `test/unit-test/main.tf` file
+6. Update the `dryrun_map` variable in the `example/main.tf` file 
 
 
 ### Caveats: 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,7 +3,7 @@ module "gatekeeper" {
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
-  dryrun_map                           = { service_type = true, snippet_allowlist = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true }
   constraint_violations_max_to_display = 25
   is_production                        = terraform.workspace == local.production_workspace ? "true" : "false"
   environment_name                     = terraform.workspace == local.production_workspace ? "production" : "development"

--- a/locals.tf
+++ b/locals.tf
@@ -2,5 +2,6 @@ locals {
   constraint_map = {
     service_type = merge(yamldecode(file("${path.module}/resources/constraints/service_type.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.service_type ? "dryrun" : "deny" } })
     snippet_allowlist = merge(yamldecode(file("${path.module}/resources/constraints/snippet_allowlist.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.snippet_allowlist ? "dryrun" : "deny" } })
+    modsec_snippet_nginx_class = merge(yamldecode(file("${path.module}/resources/constraints/modsec_snippet_nginx_class.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.modsec_snippet_nginx_class ? "dryrun" : "deny" } })
   }
 }

--- a/resources/constraint_templates/modsec_snippet_nginx_class.yaml
+++ b/resources/constraint_templates/modsec_snippet_nginx_class.yaml
@@ -1,0 +1,30 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8smodsecsnippetnginxclass
+  annotations:
+    description: This policy denies any ingress that has an ingress class of "nginx" or "default" and uses the "nginx.ingress.kubernetes.io/modsecurity-snippet" annotation
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8smodsecsnippetnginxclass
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8smodsecsnippetnginxclass
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Ingress"
+          input.review.object.metadata.annotations["kubernetes.io/ingress.class"] == "nginx"
+          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
+          msg := "No modsec snippet for default ingress class"
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Ingress"
+          input.review.object.spec.ingressClassName == "default"
+          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
+          msg := "No modsec snippet for default ingress class"
+        }
+

--- a/resources/constraint_templates/service_type.yaml
+++ b/resources/constraint_templates/service_type.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8sservicetypeloadbalancer
   annotations:
-    description: Requires all Services with spec.type == "LoadBalancer" to have the correct annotation in associated namespace
+    description: Requires all Services with spec.type == "LoadBalancer" to have the correct annotation in the associated namespace
 spec:
   crd:
     spec:

--- a/resources/constraint_templates/snippet_allowlist.yaml
+++ b/resources/constraint_templates/snippet_allowlist.yaml
@@ -3,7 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8ssnippetallowlist
   annotations:
-    description: For create and update Ingress check that none of the annotations contain forbidden values
+    description: For create and update Ingress operations, check that none of the annotations contain forbidden values
 spec:
   crd:
     spec:

--- a/resources/constraints/modsec_snippet_nginx_class.yaml
+++ b/resources/constraints/modsec_snippet_nginx_class.yaml
@@ -1,0 +1,8 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8smodsecsnippetnginxclass
+metadata:
+  name: k8smodsecsnippetnginxclass
+spec:
+  match:
+    kinds:
+      - kinds: ["Ingress"]

--- a/test/suite/modsec_snippet_nginx_class.yaml
+++ b/test/suite/modsec_snippet_nginx_class.yaml
@@ -1,0 +1,24 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+- name: snippet_allowlist
+  template: ../../resources/constraint_templates/modsec_snippet_nginx_class.yaml
+  constraint: ../../resources/constraints/modsec_snippet_nginx_class.yaml
+  cases:
+  - name: allow-annotation-class-nginx
+    object: samples/modsec_snippet_nginx_class/allow_annotation_class_nginx/case.yaml
+    assertions:
+    - violations: no  
+  - name: allow-spec-ingress-class
+    object: samples/modsec_snippet_nginx_class/allow_spec_ingress_class/case.yaml
+    assertions:
+    - violations: no
+  - name: deny-annotation
+    object: samples/modsec_snippet_nginx_class/deny_annotation/case.yaml
+    assertions:
+    - violations: yes
+  - name: deny-spec
+    object: samples/modsec_snippet_nginx_class/deny_spec/case.yaml
+    assertions:
+    - violations: yes
+

--- a/test/suite/samples/modsec_snippet_nginx_class/allow_annotation_class_nginx/case.yaml
+++ b/test/suite/samples/modsec_snippet_nginx_class/allow_annotation_class_nginx/case.yaml
@@ -1,0 +1,5 @@
+kind: Ingress
+metadata: 
+  annotations: 
+    kubernetes.io/ingress.class: "some-other-ingress-class"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: "other"

--- a/test/suite/samples/modsec_snippet_nginx_class/allow_spec_ingress_class/case.yaml
+++ b/test/suite/samples/modsec_snippet_nginx_class/allow_spec_ingress_class/case.yaml
@@ -1,0 +1,6 @@
+kind: Ingress
+metadata: 
+  annotations: 
+    nginx.ingress.kubernetes.io/modsecurity-snippet: "other"
+spec:
+  ingressClassName: "other"

--- a/test/suite/samples/modsec_snippet_nginx_class/deny_annotation/case.yaml
+++ b/test/suite/samples/modsec_snippet_nginx_class/deny_annotation/case.yaml
@@ -1,0 +1,5 @@
+kind: Ingress
+metadata: 
+  annotations: 
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: "true"

--- a/test/suite/samples/modsec_snippet_nginx_class/deny_spec/case.yaml
+++ b/test/suite/samples/modsec_snippet_nginx_class/deny_spec/case.yaml
@@ -1,0 +1,6 @@
+kind: Ingress
+metadata: 
+  annotations: 
+    nginx.ingress.kubernetes.io/modsecurity-snippet: "true"
+spec:
+  ingressClassName: "default"

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -7,7 +7,7 @@ module "gatekeeper" {
   source = "../../"
 
   cluster_domain_name                  = "gatekeeper.cloud-platform.service.justice.gov.uk"
-  dryrun_map                           = { service_type = true, snippet_allowlist = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true }
   constraint_violations_max_to_display = 25
   is_production                        = "false"
   environment_name                     = "development"

--- a/variables.tf
+++ b/variables.tf
@@ -48,5 +48,6 @@ variable "dryrun_map" {
   type = object({
     service_type = bool
     snippet_allowlist = bool
+    modsec_snippet_nginx_class = bool
   })
 }


### PR DESCRIPTION
- Updating some descriptions of rules
- Update README.md for adding variables
- Migrate modsec_snippet_nginx_class constraint and tests