### PR TITLE
Migrating external dns weight constraint and tests from OPA to gatekeeper

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,7 +3,7 @@ module "gatekeeper" {
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
-  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true, external_dns_weight = true }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25
   is_production                        = terraform.workspace == local.production_workspace ? "true" : "false"

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints.
   constraint_map = {
     service_type                    = merge(yamldecode(file("${path.module}/resources/constraints/service_type.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.service_type ? "dryrun" : "deny" } })
     snippet_allowlist               = merge(yamldecode(file("${path.module}/resources/constraints/snippet_allowlist.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.snippet_allowlist ? "dryrun" : "deny" } })
@@ -6,6 +7,7 @@ locals {
     modsec_nginx_class              = merge(yamldecode(file("${path.module}/resources/constraints/modsec_nginx_class.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.modsec_nginx_class ? "dryrun" : "deny" } })
     ingress_clash                   = merge(yamldecode(file("${path.module}/resources/constraints/ingress_clash.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.ingress_clash ? "dryrun" : "deny" } })
     hostname_length                 = merge(yamldecode(file("${path.module}/resources/constraints/ingress_hostname_length.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.hostname_length ? "dryrun" : "deny" } })
-    ingress_external_dns_identifier = merge(yamldecode(file("${path.module}/resources/constraints/ingress_external_dns_identifier.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.external_dns_identifier ? "dryrun" : "deny", "parameters" : { "cluster_color" : var.cluster_color } } })
+    external_dns_weight             = merge(yamldecode(file("${path.module}/resources/constraints/ingress_external_dns_weight.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.external_dns_weight ? "dryrun" : "deny" } })
+    external_dns_identifier         = merge(yamldecode(file("${path.module}/resources/constraints/ingress_external_dns_identifier.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.external_dns_identifier ? "dryrun" : "deny", "parameters" : { "cluster_color" : var.cluster_color } } })
   }
 }

--- a/resources/constraint_templates/ingress_clash.yaml
+++ b/resources/constraint_templates/ingress_clash.yaml
@@ -3,6 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8singressclash
   annotations:
+    metadata.gatekeeper.sh/title: Prevent conflicting hosts
     description: Prevent use of conflicting hosts in Ingress resources
 spec:
   crd:

--- a/resources/constraint_templates/ingress_external_dns_identifier.yaml
+++ b/resources/constraint_templates/ingress_external_dns_identifier.yaml
@@ -3,8 +3,8 @@ kind: ConstraintTemplate
 metadata:
   name: k8sexternaldnsidentifier
   annotations:
-    metadata.gatekeeper.sh/title: 
-    description: 
+    metadata.gatekeeper.sh/title: External DNS Identifier
+    description: This constraint checks that the set-identifier annotation follows the pattern <ingress-name>-<ns>-<cluster-colour>
 spec:
   crd:
     spec:

--- a/resources/constraint_templates/ingress_external_dns_weight.yaml
+++ b/resources/constraint_templates/ingress_external_dns_weight.yaml
@@ -1,0 +1,26 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sexternaldnsweight
+  annotations:
+    metadata.gatekeeper.sh/title: External DNS weight
+    description: This constraint checks that the aws-weight annotation is present
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8sexternaldnsweight
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sexternaldnsweight
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Ingress"
+          not input.review.object.metadata.annotations["external-dns.alpha.kubernetes.io/aws-weight"]
+          not input.review.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
+          msg := "\nPlease add valid AWS weight annotation e.g. external-dns.alpha.kubernetes.io/aws-weight: '100'"
+        }
+
+

--- a/resources/constraint_templates/modsec_nginx_class.yaml
+++ b/resources/constraint_templates/modsec_nginx_class.yaml
@@ -3,6 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8smodsecnginxclass
   annotations:
+    metadata.gatekeeper.sh/title: Modsec NGINX class
     description: This policy denies any ingress that has an ingress class of "nginx" or "default" and uses the "nginx.ingress.kubernetes.io/enable-modsecurity" annotation
 spec:
   crd:

--- a/resources/constraint_templates/modsec_snippet_nginx_class.yaml
+++ b/resources/constraint_templates/modsec_snippet_nginx_class.yaml
@@ -3,6 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8smodsecsnippetnginxclass
   annotations:
+    metadata.gatekeeper.sh/title: Modsec snippet NGINX
     description: This policy denies any ingress that has an ingress class of "nginx" or "default" and uses the "nginx.ingress.kubernetes.io/modsecurity-snippet" annotation
 spec:
   crd:

--- a/resources/constraints/ingress_external_dns_weight.yaml
+++ b/resources/constraints/ingress_external_dns_weight.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8sexternaldnsweight
+metadata:
+  name: k8sexternaldnsweight
+spec:
+  match:
+    kinds:
+      - kinds: ["Ingress"]
+        apiGroups: ["extensions", "networking.k8s.io"]
+

--- a/test/suite/ingress_external_dns_weight.yaml
+++ b/test/suite/ingress_external_dns_weight.yaml
@@ -1,0 +1,28 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+- name: external_dns_weight
+  template: ../../resources/constraint_templates/ingress_external_dns_weight.yaml
+  constraint: ../../resources/constraints/ingress_external_dns_weight.yaml
+  cases:
+  - name: allow-ignore-true
+    object: samples/external_dns_weight/allow_ignore_true/case.yaml
+    assertions:
+    - violations: no
+  - name: allow-weight
+    object: samples/external_dns_weight/allow_weight/case.yaml
+    assertions:
+    - violations: no
+  - name: deny-ignore-false
+    object: samples/external_dns_weight/deny_ignore_false/case.yaml
+    assertions:
+    - violations: yes
+  - name: deny-no-annotations
+    object: samples/external_dns_weight/deny_no_annotations/case.yaml
+    assertions:
+    - violations: yes
+  - name: deny-no-weight
+    object: samples/external_dns_weight/deny_no_weight/case.yaml
+    assertions:
+    - violations: yes
+

--- a/test/suite/samples/external_dns_weight/allow_ignore_true/case.yaml
+++ b/test/suite/samples/external_dns_weight/allow_ignore_true/case.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-0
+  namespace: default
+  annotations:
+    cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"
+spec:
+  rules:
+  - host: ing-0.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80

--- a/test/suite/samples/external_dns_weight/allow_weight/case.yaml
+++ b/test/suite/samples/external_dns_weight/allow_weight/case.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-0
+  namespace: default
+  annotations:
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+spec:
+  rules:
+  - host: ing-0.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80

--- a/test/suite/samples/external_dns_weight/deny_ignore_false/case.yaml
+++ b/test/suite/samples/external_dns_weight/deny_ignore_false/case.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-0
+  namespace: default
+  annotations:
+    cloud-platform.justice.gov.uk/ignore-external-dns-weight: "false"
+spec:
+  rules:
+  - host: ing-0.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80

--- a/test/suite/samples/external_dns_weight/deny_no_annotations/case.yaml
+++ b/test/suite/samples/external_dns_weight/deny_no_annotations/case.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-0
+  namespace: default
+spec:
+  rules:
+  - host: ing-0.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80

--- a/test/suite/samples/external_dns_weight/deny_no_weight/case.yaml
+++ b/test/suite/samples/external_dns_weight/deny_no_weight/case.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-0
+  namespace: default
+  annotations:
+    external-dns.alpha.kubernetes.io/aws-weight: false
+spec:
+  rules:
+  - host: ing-0.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -7,7 +7,7 @@ module "gatekeeper" {
   source = "../../"
 
   cluster_domain_name                  = "gatekeeper.cloud-platform.service.justice.gov.uk"
-  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true, external_dns_weight = true }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25
   is_production                        = "false"

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,7 @@ variable "dryrun_map" {
     ingress_clash              = bool
     hostname_length            = bool
     external_dns_identifier    = bool
+    external_dns_weight = bool
   })
 }
 


### PR DESCRIPTION
- Migrated the external dns weight constraint and tests to gatekeeper
- updated titles and descriptions on some other constraints