### PR TITLE
SA secret delete warning and allow constraints on delete operations

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,7 +3,7 @@ module "gatekeeper" {
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
-  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true, external_dns_weight = true, valid_hostname = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true, external_dns_weight = true, valid_hostname = true, warn_service_account_secret_delete = true }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25
   is_production                        = terraform.workspace == local.production_workspace ? "true" : "false"

--- a/locals.tf
+++ b/locals.tf
@@ -1,14 +1,15 @@
 locals {
   # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints.
   constraint_map = {
-    service_type               = merge(yamldecode(file("${path.module}/resources/constraints/service_type.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.service_type ? "dryrun" : "deny" } })
-    snippet_allowlist          = merge(yamldecode(file("${path.module}/resources/constraints/snippet_allowlist.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.snippet_allowlist ? "dryrun" : "deny" } })
-    modsec_snippet_nginx_class = merge(yamldecode(file("${path.module}/resources/constraints/modsec_snippet_nginx_class.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.modsec_snippet_nginx_class ? "dryrun" : "deny" } })
-    modsec_nginx_class         = merge(yamldecode(file("${path.module}/resources/constraints/modsec_nginx_class.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.modsec_nginx_class ? "dryrun" : "deny" } })
-    ingress_clash              = merge(yamldecode(file("${path.module}/resources/constraints/ingress_clash.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.ingress_clash ? "dryrun" : "deny" } })
-    hostname_length            = merge(yamldecode(file("${path.module}/resources/constraints/ingress_hostname_length.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.hostname_length ? "dryrun" : "deny" } })
-    external_dns_weight        = merge(yamldecode(file("${path.module}/resources/constraints/ingress_external_dns_weight.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.external_dns_weight ? "dryrun" : "deny" } })
-    external_dns_identifier    = merge(yamldecode(file("${path.module}/resources/constraints/ingress_external_dns_identifier.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.external_dns_identifier ? "dryrun" : "deny", "parameters" : { "clusterColor" : var.cluster_color } } })
-    valid_hostname             = merge(yamldecode(file("${path.module}/resources/constraints/ingress_valid_hostname.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.valid_hostname ? "dryrun" : "deny", "parameters" : { "validDomainNames" : "*.${var.cluster_domain_name},*.${var.integration_test_zone}" } } })
+    service_type                        = merge(yamldecode(file("${path.module}/resources/constraints/service_type.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.service_type ? "dryrun" : "deny" } })
+    snippet_allowlist                   = merge(yamldecode(file("${path.module}/resources/constraints/snippet_allowlist.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.snippet_allowlist ? "dryrun" : "deny" } })
+    modsec_snippet_nginx_class          = merge(yamldecode(file("${path.module}/resources/constraints/modsec_snippet_nginx_class.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.modsec_snippet_nginx_class ? "dryrun" : "deny" } })
+    modsec_nginx_class                  = merge(yamldecode(file("${path.module}/resources/constraints/modsec_nginx_class.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.modsec_nginx_class ? "dryrun" : "deny" } })
+    ingress_clash                       = merge(yamldecode(file("${path.module}/resources/constraints/ingress_clash.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.ingress_clash ? "dryrun" : "deny" } })
+    hostname_length                     = merge(yamldecode(file("${path.module}/resources/constraints/ingress_hostname_length.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.hostname_length ? "dryrun" : "deny" } })
+    external_dns_weight                 = merge(yamldecode(file("${path.module}/resources/constraints/ingress_external_dns_weight.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.external_dns_weight ? "dryrun" : "deny" } })
+    external_dns_identifier             = merge(yamldecode(file("${path.module}/resources/constraints/ingress_external_dns_identifier.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.external_dns_identifier ? "dryrun" : "deny", "parameters" : { "clusterColor" : var.cluster_color } } })
+    valid_hostname                      = merge(yamldecode(file("${path.module}/resources/constraints/ingress_valid_hostname.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.valid_hostname ? "dryrun" : "deny", "parameters" : { "validDomainNames" : "*.${var.cluster_domain_name},*.${var.integration_test_zone}" } } })
+    warn_service_account_secret_delete  = merge(yamldecode(file("${path.module}/resources/constraints/warn_service_account_secret_delete.yaml")), { "spec" : { "enforcementAction" : var.dryrun_map.warn_service_account_secret_delete ? "dryrun" : "warn"} })
   }
 }

--- a/resources/constraint_templates/warn_service_account_secret_delete.yaml
+++ b/resources/constraint_templates/warn_service_account_secret_delete.yaml
@@ -1,0 +1,25 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8swarnserviceaccountsecretdelete
+  annotations:
+    metadata.gatekeeper.sh/title: Warn Service Account Secret delete
+    description: This policy warns any time a service account secret token is deleted with the type "kubernetes.io/service-account-token"
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8swarnserviceaccountsecretdelete
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8swarnserviceaccountsecretdelete
+
+        operations = {"DELETE"}
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Secret"
+          input.review.object.type == "kubernetes.io/service-account-token"
+          operations[input.review.operation]
+          msg := "Since Kubernetes 1.24, the ability to rotate service account tokens by deleting the secret has been deprecated. Cloud Platform recommends using the `cloud-platform-terraform-serviceaccount` module instead. You can find more info here - https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rotate-tokens-keys.html"
+        }

--- a/resources/constraints/warn_service_account_secret_delete.yaml
+++ b/resources/constraints/warn_service_account_secret_delete.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8swarnserviceaccountsecretdelete
+metadata:
+  name: k8swarnserviceaccountsecretdelete
+spec:
+  enforcementAction: warn
+  match:
+    kinds:
+      - kinds: ["Secret"]
+

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,5 +1,6 @@
 constraintViolationsLimit: ${constraint_violations_max_to_display}
 auditFromCache: ${audit_from_cache}
+enableDeleteOperations: true
 postInstall:
   labelNamespace:
     enabled: ${post_install_label_namespace}

--- a/test/suite/samples/warn_service_account_secret_delete/allow_other_secret_delete/case.yaml
+++ b/test/suite/samples/warn_service_account_secret_delete/allow_other_secret_delete/case.yaml
@@ -1,0 +1,25 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    kind: Secret
+
+  operation: "DELETE"
+
+  name: secret-basic-auth
+
+  namespace: ns-0
+  
+  oldObject:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: secret-basic-auth
+      namespace: ns-0
+      annotations:
+        kubernetes.io/service-account.name: cd-serviceaccount
+        kubernetes.io/service-account.uid: s0m3-str1ng
+    type: kubernetes.io/basic-auth
+    stringData:
+      username: admin # required field for kubernetes.io/basic-auth
+      password: t0p-Secret # required field for kubernetes.io/basic-auth

--- a/test/suite/samples/warn_service_account_secret_delete/allow_service_account_secret_create/case.yaml
+++ b/test/suite/samples/warn_service_account_secret_delete/allow_service_account_secret_create/case.yaml
@@ -1,0 +1,26 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    kind: Secret
+
+  operation: "CREATE"
+
+  name: cd-serviceaccount-token
+
+  namespace: ns-0
+  
+  oldObject:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cd-serviceaccount-token
+      namespace: ns-0
+      annotations:
+        kubernetes.io/service-account.name: cd-serviceaccount
+        kubernetes.io/service-account.uid: s0m3-str1ng
+    type: kubernetes.io/service-account-token
+    data:
+      ca.crt: SOMESTRING
+      namespace: s0m3str1ng
+      token: SOMESTRING

--- a/test/suite/samples/warn_service_account_secret_delete/allow_service_account_secret_update/case.yaml
+++ b/test/suite/samples/warn_service_account_secret_delete/allow_service_account_secret_update/case.yaml
@@ -1,0 +1,26 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    kind: Secret
+
+  operation: "UPDATE"
+
+  name: cd-serviceaccount-token
+
+  namespace: ns-0
+  
+  oldObject:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cd-serviceaccount-token
+      namespace: ns-0
+      annotations:
+        kubernetes.io/service-account.name: cd-serviceaccount
+        kubernetes.io/service-account.uid: s0m3-str1ng
+    type: kubernetes.io/service-account-token
+    data:
+      ca.crt: SOMESTRING
+      namespace: s0m3str1ng
+      token: SOMESTRING

--- a/test/suite/samples/warn_service_account_secret_delete/warn_service_account_secret_delete/case.yaml
+++ b/test/suite/samples/warn_service_account_secret_delete/warn_service_account_secret_delete/case.yaml
@@ -1,0 +1,26 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    kind: Secret
+
+  operation: "DELETE"
+
+  name: cd-serviceaccount-token
+
+  namespace: ns-0
+  
+  oldObject:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cd-serviceaccount-token
+      namespace: ns-0
+      annotations:
+        kubernetes.io/service-account.name: cd-serviceaccount
+        kubernetes.io/service-account.uid: s0m3-str1ng
+    type: kubernetes.io/service-account-token
+    data:
+      ca.crt: SOMESTRING
+      namespace: s0m3str1ng
+      token: SOMESTRING

--- a/test/suite/warn_service_account_secret_delete.yaml
+++ b/test/suite/warn_service_account_secret_delete.yaml
@@ -1,0 +1,23 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+- name: warn_service_account_secret_delete
+  template: ../../resources/constraint_templates/warn_service_account_secret_delete.yaml
+  constraint: ../../resources/constraints/warn_service_account_secret_delete.yaml
+  cases:
+  - name: allow-other-secret-delete
+    object: samples/warn_service_account_secret_delete/allow_other_secret_delete/case.yaml
+    assertions:
+    - violations: no
+  - name: allow-service-account-secret-create
+    object: samples/warn_service_account_secret_delete/allow_service_account_secret_create/case.yaml
+    assertions:
+    - violations: no
+  - name: allow-service-account-secret-update
+    object: samples/warn_service_account_secret_delete/allow_service_account_secret_update/case.yaml
+    assertions:
+    - violations: no
+  - name: warn-service-account-secret-delete
+    object: samples/warn_service_account_secret_delete/warn_service_account_secret_delete/case.yaml
+    assertions:
+    - violations: yes

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -7,7 +7,7 @@ module "gatekeeper" {
   source = "../../"
 
   cluster_domain_name                  = "gatekeeper.cloud-platform.service.justice.gov.uk"
-  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true, external_dns_weight = true, valid_hostname = true }
+  dryrun_map                           = { service_type = true, snippet_allowlist = true, modsec_snippet_nginx_class = true, modsec_nginx_class = true, ingress_clash = true, hostname_length = true, external_dns_identifier = true, external_dns_weight = true, valid_hostname = true, warn_service_account_secret_delete = true }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25
   is_production                        = "false"

--- a/variables.tf
+++ b/variables.tf
@@ -57,15 +57,16 @@ variable "cluster_color" {
 variable "dryrun_map" {
   description = "run constraints in dryrun mode "
   type = object({
-    service_type               = bool
-    snippet_allowlist          = bool
-    modsec_snippet_nginx_class = bool
-    modsec_nginx_class         = bool
-    ingress_clash              = bool
-    hostname_length            = bool
-    external_dns_identifier    = bool
-    external_dns_weight        = bool
-    valid_hostname             = bool
+    service_type                        = bool
+    snippet_allowlist                   = bool
+    modsec_snippet_nginx_class          = bool
+    modsec_nginx_class                  = bool
+    ingress_clash                       = bool
+    hostname_length                     = bool
+    external_dns_identifier             = bool
+    external_dns_weight                 = bool
+    valid_hostname                      = bool
+    warn_service_account_secret_delete  = bool
   })
 }
 


### PR DESCRIPTION
New constraint and tests to warn when service account token secrets are deleted and update Gatekeeper to allow constraints on delete operations

<img width="947" alt="Screenshot 2023-07-27 at 12 27 16" src="https://github.com/ministryofjustice/cloud-platform-terraform-gatekeeper/assets/51861897/49554403-7f7f-4627-9dba-38b527ac166e">

