### PR TITLE
add smoketest-psp namespaces to restricted mutation exclusions

### DIFF
--- a/resources/mutations/annotate_seccomp.yaml
+++ b/resources/mutations/annotate_seccomp.yaml
@@ -19,6 +19,7 @@ spec:
       "kuberos",
       "logging",
       "monitoring",
+      "smoketest-psp-*",
       "tigera-operator",
       "trivy-system",
       "velero"

--- a/resources/mutations/containers_drop_all_cap.yaml
+++ b/resources/mutations/containers_drop_all_cap.yaml
@@ -23,6 +23,7 @@ spec:
       "kuberos",
       "logging",
       "monitoring",
+      "smoketest-psp-*",
       "tigera-operator",
       "trivy-system",
       "velero"

--- a/resources/mutations/default_fs_group.yaml
+++ b/resources/mutations/default_fs_group.yaml
@@ -23,6 +23,7 @@ spec:
       "kuberos",
       "logging",
       "monitoring",
+      "smoketest-psp-*",
       "tigera-operator",
       "trivy-system",
       "velero"

--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -23,6 +23,7 @@ spec:
       "kuberos",
       "logging",
       "monitoring",
+      "smoketest-psp-*",
       "tigera-operator",
       "trivy-system",
       "velero"

--- a/resources/mutations/default_supplemental_groups.yaml
+++ b/resources/mutations/default_supplemental_groups.yaml
@@ -23,6 +23,7 @@ spec:
       "kuberos",
       "logging",
       "monitoring",
+      "smoketest-psp-*",
       "tigera-operator",
       "trivy-system",
       "velero"

--- a/resources/mutations/deny_privlige_escalation.yaml
+++ b/resources/mutations/deny_privlige_escalation.yaml
@@ -23,6 +23,7 @@ spec:
       "kuberos",
       "logging",
       "monitoring",
+      "smoketest-psp-*",
       "tigera-operator",
       "trivy-system",
       "velero"

--- a/resources/mutations/run_as_non_root.yaml
+++ b/resources/mutations/run_as_non_root.yaml
@@ -23,6 +23,7 @@ spec:
       "kuberos",
       "logging",
       "monitoring",
+      "smoketest-psp-*",
       "tigera-operator",
       "trivy-system",
       "velero",


### PR DESCRIPTION
Whilst we still have psp restricted active, this measure ensures psp smoketest can pass on privileged test.