### PR TITLE
🙅 Do not validate cert-manager HTTP01 ingresses

### DIFF
--- a/resources/constraint_templates/ingress_external_dns_identifier.yaml
+++ b/resources/constraint_templates/ingress_external_dns_identifier.yaml
@@ -24,8 +24,8 @@ spec:
 
         violation[{"msg": msg}] {
           input.review.kind.kind == "Ingress"
-          not input.review.object.metadata.annotations["external-dns.alpha.kubernetes.io/set-identifier"] == concat("-", [input.review.object.metadata.name, input.review.object.metadata.namespace, input.parameters.clusterColor])
-          not input.review.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
-          msg := sprintf("\nPlease add valid external-dns set-identifier annotation for ingress %v/%v, remember: <ingress-name>-<ns>-${clusterColor}", [input.review.object.metadata.namespace, input.review.object.metadata.name])
-        }
-
+            not startswith(input.review.object.metadata.name, "cm-acme-http-solver")
+            not input.review.object.metadata.annotations["external-dns.alpha.kubernetes.io/set-identifier"] == concat("-", [input.review.object.metadata.name, input.review.object.metadata.namespace, input.parameters.clusterColor])
+            not input.review.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
+            msg := sprintf("\nPlease add valid external-dns set-identifier annotation for ingress %v/%v, remember: <ingress-name>-<ns>-${clusterColor}", [input.review.object.metadata.namespace, input.review.object.metadata.name])
+          }

--- a/resources/constraint_templates/ingress_external_dns_weight.yaml
+++ b/resources/constraint_templates/ingress_external_dns_weight.yaml
@@ -18,9 +18,8 @@ spec:
 
         violation[{"msg": msg}] {
           input.review.kind.kind == "Ingress"
+          not startswith(input.review.object.metadata.name, "cm-acme-http-solver")
           not input.review.object.metadata.annotations["external-dns.alpha.kubernetes.io/aws-weight"]
           not input.review.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
           msg := "\nPlease add valid AWS weight annotation e.g. external-dns.alpha.kubernetes.io/aws-weight: '100'"
         }
-
-

--- a/test/suite/ingress_external_dns_identifier.yaml
+++ b/test/suite/ingress_external_dns_identifier.yaml
@@ -17,6 +17,10 @@ tests:
     object: samples/external_dns_identifier/allow_ignore/case.yaml
     assertions:
     - violations: no
+  - name: allow-cert-manager
+    object: samples/external_dns_identifier/allow_cert_manager/case.yaml
+    assertions:
+    - violations: no
   - name: deny-false-ignore
     object: samples/external_dns_identifier/deny_false_ignore/case.yaml
     assertions:

--- a/test/suite/ingress_external_dns_weight.yaml
+++ b/test/suite/ingress_external_dns_weight.yaml
@@ -13,6 +13,10 @@ tests:
     object: samples/external_dns_weight/allow_weight/case.yaml
     assertions:
     - violations: no
+  - name: allow-cert-manager
+    object: samples/external_dns_weight/allow_cert_manager/case.yaml
+    assertions:
+    - violations: no
   - name: deny-ignore-false
     object: samples/external_dns_weight/deny_ignore_false/case.yaml
     assertions:

--- a/test/suite/samples/external_dns_identifier/allow_cert_manager/case.yaml
+++ b/test/suite/samples/external_dns_identifier/allow_cert_manager/case.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cm-acme-http-solver-12345
+  namespace: default
+spec:
+  rules:
+  - host: ingress.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80
+

--- a/test/suite/samples/external_dns_weight/allow_cert_manager/case.yaml
+++ b/test/suite/samples/external_dns_weight/allow_cert_manager/case.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cm-acme-http-solver-12345
+  namespace: default
+spec:
+  rules:
+  - host: ingress.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80
+


### PR DESCRIPTION
Following on from https://github.com/ministryofjustice/cloud-platform-environments/pull/17771, we're still unable to obtain certificates using HTTP01 on Cloud Platform

This pull request excludes ingresses starting with `cm-acme-http-solver`