### PR TITLE
Exclude kuberhealthy from ns label restricted check

### DIFF
--- a/resources/constraints/user_ns_requires_psa_label.yaml
+++ b/resources/constraints/user_ns_requires_psa_label.yaml
@@ -18,6 +18,7 @@ spec:
       "kube-node-lease",
       "kube-public",
       "default",
+      "kuberhealthy",
       "kuberos",
       "logging",
       "monitoring",


### PR DESCRIPTION
kuberhealthy namespace is updated with privileged namespace so ignore from psa label constraint