### PR TITLE
Add constraint to lock linux capabilities for prilvileged system namespaces

### DIFF
--- a/constraints/locals.tf
+++ b/constraints/locals.tf
@@ -13,6 +13,7 @@ locals {
   deprecated_apis_1_26_yaml               = yamldecode(file("${path.module}/../resources/constraints/deprecated_apis_1.26.yaml"))
   deprecated_apis_1_27_yaml               = yamldecode(file("${path.module}/../resources/constraints/deprecated_apis_1.27.yaml"))
   deprecated_apis_1_29_yaml               = yamldecode(file("${path.module}/../resources/constraints/deprecated_apis_1.29.yaml"))
+  lock_priv_capabilities_yaml                  = yamldecode(file("${path.module}/../resources/constraints/lock_priv_capabilities.yaml"))
 
   # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints. -- we merge in the spec separately to avoid overwriting entire spec key
   constraint_map = {
@@ -30,5 +31,6 @@ locals {
     deprecated_apis_1_26               = merge(local.deprecated_apis_1_26_yaml, { "spec" : merge(local.deprecated_apis_1_26_yaml["spec"], { "enforcementAction" : var.dryrun_map.deprecated_apis_1_26 ? "dryrun" : "deny" }) })
     deprecated_apis_1_27               = merge(local.deprecated_apis_1_27_yaml, { "spec" : merge(local.deprecated_apis_1_27_yaml["spec"], { "enforcementAction" : var.dryrun_map.deprecated_apis_1_27 ? "dryrun" : "deny" }) })
     deprecated_apis_1_29               = merge(local.deprecated_apis_1_29_yaml, { "spec" : merge(local.deprecated_apis_1_29_yaml["spec"], { "enforcementAction" : var.dryrun_map.deprecated_apis_1_29 ? "dryrun" : "deny" }) })
+    lock_priv_capabilities            = merge(local.lock_priv_capabilities_yaml, { "spec" : merge(local.lock_priv_capabilities_yaml["spec"], { "enforcementAction" : var.dryrun_map.lock_priv_capabilities ? "dryrun" : "deny" }) })
   }
 }

--- a/constraints/variables.tf
+++ b/constraints/variables.tf
@@ -30,6 +30,7 @@ variable "dryrun_map" {
     deprecated_apis_1_26               = bool
     deprecated_apis_1_27               = bool
     deprecated_apis_1_29               = bool
+    lock_priv_capabilities            = bool
   })
 }
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -18,6 +18,7 @@ module "gatekeeper" {
     deprecated_apis_1_26               = true,
     deprecated_apis_1_27               = true,
     deprecated_apis_1_29               = true,
+    lock_priv_capabilities            = true,
   }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25

--- a/resources/constraint_templates/lock_priv_capabilities.yaml
+++ b/resources/constraint_templates/lock_priv_capabilities.yaml
@@ -16,25 +16,22 @@ spec:
       validation:
         openAPIV3Schema:
           type: object
+          description: >-
+            Controls Linux capabilities on containers. Corresponds to the
+            `allowedCapabilities` and `requiredDropCapabilities` fields in a
+            PodSecurityPolicy. For more information, see
+            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#capabilities
           properties:
-            kvs:
+            allowedCapabilities:
               type: array
-              description: >-
-                Controls Linux capabilities on containers on psa labels with privileged. This is to ensure the namespaces are locked down to the same level as they were when custom PSPs were implemented. This corresponds to the
-                `allowedCapabilities` and `requiredDropCapabilities` fields in a PodSecurityPolicy.
+              description: A list of Linux capabilities that can be added to a container.
               items:
-                type: object
-                properties:
-                  allowedCapabilities:
-                    type: array
-                    description: A list of Linux capabilities that can be added to a container.
-                    items:
-                      type: string
-                  requiredDropCapabilities:
-                    type: array
-                    description: A list of Linux capabilities that are required to be dropped from a container.
-                    items:
-                      type: string
+                type: string
+            requiredDropCapabilities:
+              type: array
+              description: A list of Linux capabilities that are required to be dropped from a container.
+              items:
+                type: string
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
@@ -48,7 +45,7 @@ spec:
 
           container := input.review.object.spec.containers[_]
           has_disallowed_capabilities(container)
-          msg := sprintf("container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, input.parameters.allowedCapabilities])
+          msg := sprintf("container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
         }
 
         violation[{"msg": msg}] {

--- a/resources/constraint_templates/lock_priv_capabilities.yaml
+++ b/resources/constraint_templates/lock_priv_capabilities.yaml
@@ -1,0 +1,123 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: lockprivcapabilities
+  annotations:
+    metadata.gatekeeper.sh/title: "Lock capabilities for namespaces with psa - PSA"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Controls Linux capabilities on containers on psa labels with privileged. This is to ensure the namespaces are locked down to the same level as they were when custom PSPs were implemented. This corresponds to the
+      `allowedCapabilities` and `requiredDropCapabilities` fields in a PodSecurityPolicy.
+spec:
+  crd:
+    spec:
+      names:
+        kind: LockPrivCapabilities
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            kvs:
+              type: array
+              description: >-
+                Controls Linux capabilities on containers on psa labels with privileged. This is to ensure the namespaces are locked down to the same level as they were when custom PSPs were implemented. This corresponds to the
+                `allowedCapabilities` and `requiredDropCapabilities` fields in a PodSecurityPolicy.
+              items:
+                type: object
+                properties:
+                  allowedCapabilities:
+                    type: array
+                    description: A list of Linux capabilities that can be added to a container.
+                    items:
+                      type: string
+                  requiredDropCapabilities:
+                    type: array
+                    description: A list of Linux capabilities that are required to be dropped from a container.
+                    items:
+                      type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package lockprivcapabilities
+
+        import data.lib.exclude_update.is_update
+
+        violation[{"msg": msg}] {
+          # spec.containers.securityContext.capabilities field is immutable.
+          not is_update(input.review)
+
+          container := input.review.object.spec.containers[_]
+          has_disallowed_capabilities(container)
+          msg := sprintf("container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, input.parameters.allowedCapabilities])
+        }
+
+        violation[{"msg": msg}] {
+          not is_update(input.review)
+          container := input.review.object.spec.containers[_]
+          missing_drop_capabilities(container)
+          msg := sprintf("container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
+        }
+
+
+
+        violation[{"msg": msg}] {
+          not is_update(input.review)
+          container := input.review.object.spec.initContainers[_]
+          has_disallowed_capabilities(container)
+          msg := sprintf("init container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
+        }
+
+        violation[{"msg": msg}] {
+          not is_update(input.review)
+          container := input.review.object.spec.initContainers[_]
+          missing_drop_capabilities(container)
+          msg := sprintf("init container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
+        }
+
+
+
+        violation[{"msg": msg}] {
+          not is_update(input.review)
+          container := input.review.object.spec.ephemeralContainers[_]
+          has_disallowed_capabilities(container)
+          msg := sprintf("ephemeral container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
+        }
+
+        violation[{"msg": msg}] {
+          not is_update(input.review)
+          container := input.review.object.spec.ephemeralContainers[_]
+          missing_drop_capabilities(container)
+          msg := sprintf("ephemeral container <%v> is not dropping all required capabilities. Container must drop all of %v or \"ALL\"", [container.name, input.parameters.requiredDropCapabilities])
+        }
+
+
+        has_disallowed_capabilities(container) {
+          allowed := {c | c := lower(input.parameters.allowedCapabilities[_])}
+          not allowed["*"]
+          capabilities := {c | c := lower(container.securityContext.capabilities.add[_])}
+
+          count(capabilities - allowed) > 0
+        }
+
+        missing_drop_capabilities(container) {
+          must_drop := {c | c := lower(input.parameters.requiredDropCapabilities[_])}
+          all := {"all"}
+          dropped := {c | c := lower(container.securityContext.capabilities.drop[_])}
+
+          count(must_drop - dropped) > 0
+          count(all - dropped) > 0
+        }
+
+        get_default(obj, param, _) := obj[param]
+
+        get_default(obj, param, _default) := _default {
+          not obj[param]
+          not obj[param] == false
+        }
+      libs:
+        - |
+          package lib.exclude_update
+
+          is_update(review) {
+              review.operation == "UPDATE"
+          }

--- a/resources/constraints/lock_priv_capabilities.yaml
+++ b/resources/constraints/lock_priv_capabilities.yaml
@@ -1,0 +1,34 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: LockPrivCapabilities
+metadata:
+  name: lockprivcapabilities
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces: [
+      "calico-apiserver",
+      "calico-system",
+      "cert-manager",
+      "concourse",
+      "gatekeeper-system",
+      "kuberhealthy",
+      "kuberos",
+      "logging",
+      "monitoring",
+      "smoketest-psa-*",
+      "tigera-operator",
+      "cloud-platform-canary-app-eks",
+      "trivy-system",
+      "velero"
+    ]
+    excludedNamespaces: [
+      "ingress-controllers",
+      "kube-system",
+      "kube-node-lease",
+      "kube-public",
+    ]
+  parameters:
+    allowedCapabilities: ["NET_BIND_SERVICE","NET_ADMIN"]
+    requiredDropCapabilities: ["NET_RAW"]

--- a/resources/constraints/lock_priv_capabilities.yaml
+++ b/resources/constraints/lock_priv_capabilities.yaml
@@ -22,13 +22,13 @@ spec:
       "cloud-platform-canary-app-eks",
       "trivy-system",
       "velero"
-    ]
+      ]
     excludedNamespaces: [
       "ingress-controllers",
       "kube-system",
       "kube-node-lease",
       "kube-public",
-    ]
+      ]
   parameters:
     allowedCapabilities: ["NET_BIND_SERVICE","NET_ADMIN"]
     requiredDropCapabilities: ["NET_RAW"]

--- a/test/suite/lock_priv_capabilities.yaml
+++ b/test/suite/lock_priv_capabilities.yaml
@@ -1,0 +1,25 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: lockprivcapabilities
+tests:
+  - name: lockprivcapabilities
+    template: ../../resources/constraint_templates/lock_priv_capabilities.yaml
+    constraint: ../../resources/constraints/lock_priv_capabilities.yaml
+    cases:
+      - name: example-disallowed
+        object: samples/lock_priv_capabilities/disallowed.yaml
+        assertions:
+          - violations: yes
+      - name: example-allowed
+        object: samples/lock_priv_capabilities/allowed.yaml
+        assertions:
+          - violations: no
+      - name: disallowed-ephemeral
+        object: samples/lock_priv_capabilities/disallowed_ephemeral.yaml
+        assertions:
+          - violations: yes
+      - name: update
+        object: samples/lock_priv_capabilities/update.yaml
+        assertions:
+          - violations: no

--- a/test/suite/samples/lock_priv_capabilities/allowed.yaml
+++ b/test/suite/samples/lock_priv_capabilities/allowed.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: opa-allowed
+  namespace: monitoring
+spec:
+  containers:
+    - name: opa
+      image: openpolicyagent/opa:0.9.2
+      args:
+        - "run"
+        - "--server"
+        - "--addr=localhost:8080"
+      securityContext:
+        capabilities:
+          add: ["NET_BIND_SERVICE", "NET_ADMIN"]
+          drop: ["NET_RAW"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/test/suite/samples/lock_priv_capabilities/disallowed.yaml
+++ b/test/suite/samples/lock_priv_capabilities/disallowed.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: opa-disallowed
+  namespace: monitoring
+spec:
+  containers:
+    - name: opa
+      image: openpolicyagent/opa:0.9.2
+      args:
+        - "run"
+        - "--server"
+        - "--addr=localhost:8080"
+      securityContext:
+        capabilities:
+          add: ["NET_RAW"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/test/suite/samples/lock_priv_capabilities/disallowed_ephemeral.yaml
+++ b/test/suite/samples/lock_priv_capabilities/disallowed_ephemeral.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: opa-disallowed
+  namespace: monitoring
+spec:
+  ephemeralContainers:
+    - name: opa
+      image: openpolicyagent/opa:0.9.2
+      args:
+        - "run"
+        - "--server"
+        - "--addr=localhost:8080"
+      securityContext:
+        capabilities:
+          add: ["NET_RAW"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "30Mi"

--- a/test/suite/samples/lock_priv_capabilities/update.yaml
+++ b/test/suite/samples/lock_priv_capabilities/update.yaml
@@ -1,0 +1,25 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  operation: "UPDATE"
+  object:
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: opa-disallowed
+      namespace: monitoring
+    spec:
+      containers:
+        - name: opa
+          image: openpolicyagent/opa:0.9.2
+          args:
+            - "run"
+            - "--server"
+            - "--addr=localhost:8080"
+          securityContext:
+            capabilities:
+              add: ["NET_RAW"]
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "30Mi"

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -22,6 +22,7 @@ module "gatekeeper" {
     deprecated_apis_1_26               = true,
     deprecated_apis_1_27               = true,
     deprecated_apis_1_29               = true,
+    lock_priv_capabilities            = true,
   }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,7 @@ variable "dryrun_map" {
     deprecated_apis_1_26               = bool
     deprecated_apis_1_27               = bool
     deprecated_apis_1_29               = bool
+    lock_priv_capabilities            = bool
   })
 }
 


### PR DESCRIPTION
This PR add a constraint to check for securityContext -> capabilities on container spec with values either to drop ALL or NET_RAW. 

Pre PSA era, the namespaces which are included all have containers running either with drop ALL or NET_RAW using their own custom PSP and serviceAccounts. This PR will lock down the privileges to the same level in dry-run mode

There are quite a list of violations as a result of this constraint and hence this constraint WILL run as a dry-run in the production cluster until we resolve all the violations.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/4803