### PR TITLE
Exclude tigera-operator, remove kuberhealthy

### DIFF
--- a/resources/constraints/lock_priv_capabilities.yaml
+++ b/resources/constraints/lock_priv_capabilities.yaml
@@ -14,7 +14,6 @@ spec:
       "cloud-platform-canary-app-eks",
       "concourse",
       "gatekeeper-system",
-      "kuberhealthy",
       "kuberos",
       "logging",
       "monitoring",

--- a/resources/constraints/lock_priv_capabilities.yaml
+++ b/resources/constraints/lock_priv_capabilities.yaml
@@ -11,6 +11,7 @@ spec:
       "calico-apiserver",
       "calico-system",
       "cert-manager",
+      "cloud-platform-canary-app-eks",
       "concourse",
       "gatekeeper-system",
       "kuberhealthy",
@@ -18,8 +19,6 @@ spec:
       "logging",
       "monitoring",
       "smoketest-psa-*",
-      "tigera-operator",
-      "cloud-platform-canary-app-eks",
       "trivy-system",
       "velero"
       ]
@@ -28,6 +27,7 @@ spec:
       "kube-system",
       "kube-node-lease",
       "kube-public",
+      "tigera-operator",
       ]
   parameters:
     allowedCapabilities: ["NET_BIND_SERVICE","NET_ADMIN"]

--- a/resources/constraints/lock_priv_capabilities.yaml
+++ b/resources/constraints/lock_priv_capabilities.yaml
@@ -26,6 +26,7 @@ spec:
       "kube-system",
       "kube-node-lease",
       "kube-public",
+      "kuberhealthy",
       "tigera-operator",
       ]
   parameters:


### PR DESCRIPTION
- Exclude tigera-operator namespace from lock-priv-capabilities constraint. The chart doesnt have provision to add container->securityContext->Capabilities
- Exclude kuberhealthy from lockprivcapabilities constraint. The chart doesnt support the capabilities. As of now, there is a mutating policy from Gatekeeper to add drop -> ALL. Once the chart supports, we will have to take exclude that from mutating policy and include into the constraint

Related to: https://github.com/ministryofjustice/cloud-platform/issues/5189
