### PR TITLE
fix: 🐛 kube-system needs to be allowed to create the default sa

### DIFF
--- a/resources/constraints/deny_sa.yaml
+++ b/resources/constraints/deny_sa.yaml
@@ -7,5 +7,5 @@ spec:
     kinds:
       - kinds: ["ServiceAccount"]
   parameters:
-    allowedGroups: ["system:masters", "github:webops", "system:serviceaccounts:concourse", "system:serviceaccount:kube-system:concourse-build-environments", "system:serviceaccounts:concourse-build-environments"]
+    allowedGroups: ["system:masters", "github:webops", "system:serviceaccounts:concourse", "system:serviceaccount:kube-system:concourse-build-environments", "system:serviceaccounts:concourse-build-environments", "system:serviceaccounts:kube-system"]
 


### PR DESCRIPTION
in new namespaces