### PR TITLE
feat: 🎸 block users from removing threshold rule

### DIFF
--- a/resources/constraint_templates/modsec_snippet_threshold.yaml
+++ b/resources/constraint_templates/modsec_snippet_threshold.yaml
@@ -1,0 +1,26 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8smodsecsnippetthreshold
+  annotations:
+    metadata.gatekeeper.sh/title: Modsec snippet NGINX Threshold Ignore
+    description: This policy denies any ingress that has a "nginx.ingress.kubernetes.io/modsecurity-snippet" annotation that ignores the threshold check rule
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8smodsecsnippetthreshold
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8smodsecsnippetthreshold
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Ingress"
+          input.review.object.metadata.annotations["kubernetes.io/ingress.class"] == "modsec"
+          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] == "true"
+          input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
+          contains(input.review.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"], "SecRuleRemoveById 949110")
+          msg := "You cannot remove this rule because this checks the Inbound Anomaly Score and causes memory spikes, if you do not wish to have modsec actively block requests please set `SecRuleEngine DetectionOnly`"
+        }
+

--- a/resources/constraints/modsec_snippet_threshold.yaml
+++ b/resources/constraints/modsec_snippet_threshold.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8smodsecsnippetthreshold
+metadata:
+  name: k8smodsecsnippetthreshold
+spec:
+  match:
+    kinds:
+      - kinds: ["Ingress"]
+

--- a/test/suite/samples/modsec_snippet_threshold/allow_valid/case.yaml
+++ b/test/suite/samples/modsec_snippet_threshold/allow_valid/case.yaml
@@ -1,0 +1,8 @@
+kind: Ingress
+metadata: 
+  annotations: 
+    kubernetes.io/ingress.class: "modsec"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+

--- a/test/suite/samples/modsec_snippet_threshold/deny_invalid/case.yaml
+++ b/test/suite/samples/modsec_snippet_threshold/deny_invalid/case.yaml
@@ -1,0 +1,8 @@
+kind: Ingress
+metadata: 
+  annotations: 
+    kubernetes.io/ingress.class: "modsec"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 949110
+


### PR DESCRIPTION
- users were incorrectly disabling modsec by removing the threshold check. This was resulting in large memory spikes that caused deeper node memory page fault issues. This gatekeeper rule blocks users from attempting to disable modsec by removing that rule.

https://mojdt.slack.com/archives/C8QR5FQRX/p1723116892500009