### PR TITLE
fix: 🐛 deny empty string for external-dns

### DIFF
--- a/resources/constraint_templates/ingress_external_dns_weight.yaml
+++ b/resources/constraint_templates/ingress_external_dns_weight.yaml
@@ -23,4 +23,11 @@ spec:
           msg := "\nPlease add valid AWS weight annotation e.g. external-dns.alpha.kubernetes.io/aws-weight: '100'"
         }
 
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Ingress"
+          input.review.object.metadata.annotations["external-dns.alpha.kubernetes.io/aws-weight"] == ""
+          not input.review.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
+          msg := "\nPlease add valid AWS weight annotation e.g. external-dns.alpha.kubernetes.io/aws-weight: '100'"
+        }
+
 

--- a/test/suite/ingress_external_dns_weight.yaml
+++ b/test/suite/ingress_external_dns_weight.yaml
@@ -25,4 +25,8 @@ tests:
     object: samples/external_dns_weight/deny_no_weight/case.yaml
     assertions:
     - violations: yes
+  - name: deny-empty-weight
+    object: samples/external_dns_weight/deny_empty_weight/case.yaml
+    assertions:
+    - violations: yes
 

--- a/test/suite/samples/external_dns_weight/deny_empty_weight/case.yaml
+++ b/test/suite/samples/external_dns_weight/deny_empty_weight/case.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-0
+  namespace: default
+  annotations:
+    external-dns.alpha.kubernetes.io/aws-weight: ""
+spec:
+  rules:
+  - host: ing-0.example.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80
+


### PR DESCRIPTION
deny empty str for aws-weight