### PR TITLE
chore: 🤖 rollback alekc/kubectl provider

### DIFF
--- a/constraint_templates/versions.tf
+++ b/constraint_templates/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.2"
+      version = "2.0.4"
     }
   }
 }

--- a/constraints/versions.tf
+++ b/constraints/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.2"
+      version = "2.0.4"
     }
   }
 }

--- a/mutations/versions.tf
+++ b/mutations/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.2"
+      version = "2.0.4"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.2"
+      version = "2.0.4"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
this reverts a merged dependabot PR updating the tf kubectl provider. provider bump results in all manifests requiring an update, we should test these changes in a separate ticket and ensure nothing bad happens.

https://github.com/ministryofjustice/cloud-platform/issues/6422