### PR TITLE
chore: 🤖 excluding kuberhealthy from GK mutations

### DIFF
--- a/resources/mutations/default_fs_group.yaml
+++ b/resources/mutations/default_fs_group.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.securityContext.fsGroup"
   parameters:

--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.securityContext.seccompProfile.type"
   parameters:

--- a/resources/mutations/default_supplemental_groups.yaml
+++ b/resources/mutations/default_supplemental_groups.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.securityContext.supplementalGroups"
   parameters:

--- a/resources/mutations/deny_privilege_escalation.yaml
+++ b/resources/mutations/deny_privilege_escalation.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.containers[name:*].securityContext.allowPrivilegeEscalation"
   parameters:

--- a/resources/mutations/deny_privilege_escalation_eph.yaml
+++ b/resources/mutations/deny_privilege_escalation_eph.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.ephemeralContainers[name:*].securityContext.allowPrivilegeEscalation"
   parameters:

--- a/resources/mutations/deny_privilege_escalation_init.yaml
+++ b/resources/mutations/deny_privilege_escalation_init.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.initContainers[name:*].securityContext.allowPrivilegeEscalation"
   parameters:

--- a/resources/mutations/drop_all_cap.yaml
+++ b/resources/mutations/drop_all_cap.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.containers[name:*].securityContext.capabilities.drop"
   parameters:

--- a/resources/mutations/drop_all_cap_eph.yaml
+++ b/resources/mutations/drop_all_cap_eph.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.ephemeralContainers[name:*].securityContext.capabilities.drop"
   parameters:

--- a/resources/mutations/drop_all_cap_init.yaml
+++ b/resources/mutations/drop_all_cap_init.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.initContainers[name:*].securityContext.capabilities.drop"
   parameters:

--- a/resources/mutations/run_as_non_root.yaml
+++ b/resources/mutations/run_as_non_root.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.containers[name:*].securityContext.runAsNonRoot"
   parameters:

--- a/resources/mutations/run_as_non_root_eph.yaml
+++ b/resources/mutations/run_as_non_root_eph.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.ephemeralContainers[name:*].securityContext.runAsNonRoot"
   parameters:

--- a/resources/mutations/run_as_non_root_init.yaml
+++ b/resources/mutations/run_as_non_root_init.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "kuberhealthy"
       ]
   location: "spec.initContainers[name:*].securityContext.runAsNonRoot"
   parameters:


### PR DESCRIPTION
kuberhealthy namespace operates in psa privileged mode. its possible that GK mutations are causing errors with daemonset check rollouts and triggering low priority alerts.

relates to ministryofjustice/cloud-platform#6045