### PR TITLE
Temporarily adding a dev namespace to troubleshoot prolonged Terminating pod

### DIFF
--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -29,7 +29,8 @@ spec:
       "trivy-system",
       "velero",
       "cloud-platform-canary-app-eks",
-      "kuberhealthy"
+      "kuberhealthy",
+      "hmpps-restricted-patients-api-dev"
       ]
   location: "spec.securityContext.seccompProfile.type"
   parameters:


### PR DESCRIPTION
We currently have some pods on the cluster in a Terminating state for a prolonged period. We are adding this namespace which has one of these effected pods as a troubleshooting step.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6777