### PR TITLE
chore: pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/push-terraform-module-version.yaml
+++ b/.github/workflows/push-terraform-module-version.yaml
@@ -7,7 +7,7 @@ jobs:
   push-terraform-module-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ministryofjustice/cloud-platform-environments/cmd/push-terraform-module-version@main
         env:
           API_URL: ${{ vars.TERRAFORM_MODULE_VERSIONS_API_URL }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           terraform_version: 1.2.5
           terraform_wrapper: false


### PR DESCRIPTION
### Description
This PR pins GitHub Actions to commit hashes for security.

### Related Issue
Closes https://github.com/ministryofjustice/cloud-platform-security-issues/issues/97