### PR TITLE
add skip terminating pods condition

### DIFF
--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -30,6 +30,9 @@ spec:
       "velero",
       "cloud-platform-canary-app-eks"
       ]
+  mutatingWebhookMatchConditions:
+  - name: "skip-terminating-pods"
+    expression: "object.metadata.deletionTimestamp == null"
   location: "spec.securityContext.seccompProfile.type"
   parameters:
     pathTests:


### PR DESCRIPTION
Adding the `mutatingWebhookMatchConditions` block to the `default-secomp-profile` to ensure that the mutation is only applied to Pods that are not in a terminating state. This prevents unnecessary webhook invocations during Pod deletion events.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6777