### PR TITLE
adding more skip terminating pods conditions

### DIFF
--- a/resources/mutations/default_fs_group.yaml
+++ b/resources/mutations/default_fs_group.yaml
@@ -30,6 +30,9 @@ spec:
       "velero",
       "cloud-platform-canary-app-eks"
       ]
+  mutatingWebhookMatchConditions:
+  - name: "skip-terminating-pods"
+    expression: "object.metadata.deletionTimestamp == null"      
   location: "spec.securityContext.fsGroup"
   parameters:
     pathTests:

--- a/resources/mutations/default_supplemental_groups.yaml
+++ b/resources/mutations/default_supplemental_groups.yaml
@@ -30,6 +30,9 @@ spec:
       "velero",
       "cloud-platform-canary-app-eks"
       ]
+  mutatingWebhookMatchConditions:
+  - name: "skip-terminating-pods"
+    expression: "object.metadata.deletionTimestamp == null"      
   location: "spec.securityContext.supplementalGroups"
   parameters:
     pathTests:


### PR DESCRIPTION
Adding the mutatingWebhookMatchConditions block to the `SupplementalGroups` and `FSGroup` to ensure that the mutation is only applied to Pods that are not in a terminating state. This prevents unnecessary webhook invocations during Pod deletion events.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6777

Tested on test cluster and int tests passed