### PR TITLE
Reverting Gatekeeper bump and skip terminating pods conditions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "gatekeeper" {
   namespace  = kubernetes_namespace.gatekeeper.id
   repository = "https://open-policy-agent.github.io/gatekeeper/charts"
   chart      = "gatekeeper"
-  version    = "3.18.2"
+  version    = "3.15.1"
 
   # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/values.yaml
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {

--- a/resources/mutations/default_fs_group.yaml
+++ b/resources/mutations/default_fs_group.yaml
@@ -30,9 +30,6 @@ spec:
       "velero",
       "cloud-platform-canary-app-eks"
       ]
-  mutatingWebhookMatchConditions:
-  - name: "skip-terminating-pods"
-    expression: "object.metadata.deletionTimestamp == null"      
   location: "spec.securityContext.fsGroup"
   parameters:
     pathTests:

--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -30,9 +30,6 @@ spec:
       "velero",
       "cloud-platform-canary-app-eks"
       ]
-  mutatingWebhookMatchConditions:
-  - name: "skip-terminating-pods"
-    expression: "object.metadata.deletionTimestamp == null"
   location: "spec.securityContext.seccompProfile.type"
   parameters:
     pathTests:

--- a/resources/mutations/default_supplemental_groups.yaml
+++ b/resources/mutations/default_supplemental_groups.yaml
@@ -30,9 +30,6 @@ spec:
       "velero",
       "cloud-platform-canary-app-eks"
       ]
-  mutatingWebhookMatchConditions:
-  - name: "skip-terminating-pods"
-    expression: "object.metadata.deletionTimestamp == null"      
   location: "spec.securityContext.supplementalGroups"
   parameters:
     pathTests:


### PR DESCRIPTION
Reverting Gatekeeper upgrade as the latest version causes an issue when [destroying a cluster](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/delete-cluster/jobs/delete/builds/871).

There is an https://github.com/open-policy-agent/gatekeeper/issues/3918 for this bug which should be fixed in the next Gatekeeper release. We'll revisit when there's a release for this fix.