### PR TITLE
chore: 🤖 bump chart to 3.18.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "gatekeeper" {
   namespace  = kubernetes_namespace.gatekeeper.id
   repository = "https://open-policy-agent.github.io/gatekeeper/charts"
   chart      = "gatekeeper"
-  version    = "3.15.1"
+  version    = "3.18.3"
 
   # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/values.yaml
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {


### PR DESCRIPTION
Previously we had [bump to 3.18.2](https://github.com/ministryofjustice/cloud-platform-terraform-gatekeeper/commit/2fa8bc4a58a52c51e5b76aa3e49126515aca46fb) which caused [errors when destroying a cluster](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/delete-cluster/jobs/delete/builds/871), so it was [rolled back](https://github.com/ministryofjustice/cloud-platform-terraform-gatekeeper/commit/b2ec65c5418d015e867230dbd2a7b436224335c1)

This was [identified as a bug and has been fixed](https://github.com/open-policy-agent/gatekeeper/pull/3921) in `3.18.3`

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6777.

Integration tests passed on test cluster