### PR TITLE
Temporarily adding namespace to exclude from default-seccomp-profile

### DIFF
--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "hmpps-adjustments-preprod"
       ]
   location: "spec.securityContext.seccompProfile.type"
   parameters:


### PR DESCRIPTION
Adding `hmpps-adjustments-preprod` namespace to exclude from `default-seccomp-profile` to troubleshoot stuck terminating pods.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6777