### PR TITLE
Temporarily adding namespace to exclude from more profiles

### DIFF
--- a/resources/mutations/default_fs_group.yaml
+++ b/resources/mutations/default_fs_group.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "hmpps-adjustments-preprod"
       ]
   location: "spec.securityContext.fsGroup"
   parameters:

--- a/resources/mutations/default_supplemental_groups.yaml
+++ b/resources/mutations/default_supplemental_groups.yaml
@@ -28,7 +28,8 @@ spec:
       "tigera-operator",
       "trivy-system",
       "velero",
-      "cloud-platform-canary-app-eks"
+      "cloud-platform-canary-app-eks",
+      "hmpps-adjustments-preprod"
       ]
   location: "spec.securityContext.supplementalGroups"
   parameters:


### PR DESCRIPTION
Adding `hmpps-adjustments-preprod` namespace to exclude from `default-fs-group` and `default-supplemental-groups` profile to troubleshoot stuck terminating pods.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6777