### PR TITLE
Temporarily adding namespaces to exclusion list to fix stuck terminating pods

### DIFF
--- a/resources/mutations/default_fs_group.yaml
+++ b/resources/mutations/default_fs_group.yaml
@@ -29,7 +29,20 @@ spec:
       "trivy-system",
       "velero",
       "cloud-platform-canary-app-eks",
-      "hmpps-adjustments-preprod"
+      "hmpps-adjustments-preprod",
+      "hmpps-adjustments-prod",
+      "hmpps-incentives-prod",
+      "hmpps-launchpad-prod",
+      "hmpps-locations-inside-prison-prod",
+      "hmpps-non-associations-prod",
+      "hmpps-person-record-prod",
+      "hmpps-prisoner-from-nomis-migration-prod",
+      "hmpps-prisoner-search-dev",
+      "hmpps-prisoner-search-prod",
+      "hmpps-restricted-patients-api-prod",
+      "laa-apply-for-legalaid-uat",
+      "offender-case-notes-prod",
+      "whereabouts-api-prod"
       ]
   location: "spec.securityContext.fsGroup"
   parameters:

--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -29,7 +29,20 @@ spec:
       "trivy-system",
       "velero",
       "cloud-platform-canary-app-eks",
-      "hmpps-adjustments-preprod"
+      "hmpps-adjustments-preprod",
+      "hmpps-adjustments-prod",
+      "hmpps-incentives-prod",
+      "hmpps-launchpad-prod",
+      "hmpps-locations-inside-prison-prod",
+      "hmpps-non-associations-prod",
+      "hmpps-person-record-prod",
+      "hmpps-prisoner-from-nomis-migration-prod",
+      "hmpps-prisoner-search-dev",
+      "hmpps-prisoner-search-prod",
+      "hmpps-restricted-patients-api-prod",
+      "laa-apply-for-legalaid-uat",
+      "offender-case-notes-prod",
+      "whereabouts-api-prod"
       ]
   location: "spec.securityContext.seccompProfile.type"
   parameters:

--- a/resources/mutations/default_supplemental_groups.yaml
+++ b/resources/mutations/default_supplemental_groups.yaml
@@ -29,7 +29,20 @@ spec:
       "trivy-system",
       "velero",
       "cloud-platform-canary-app-eks",
-      "hmpps-adjustments-preprod"
+      "hmpps-adjustments-preprod",
+      "hmpps-adjustments-prod",
+      "hmpps-incentives-prod",
+      "hmpps-launchpad-prod",
+      "hmpps-locations-inside-prison-prod",
+      "hmpps-non-associations-prod",
+      "hmpps-person-record-prod",
+      "hmpps-prisoner-from-nomis-migration-prod",
+      "hmpps-prisoner-search-dev",
+      "hmpps-prisoner-search-prod",
+      "hmpps-restricted-patients-api-prod",
+      "laa-apply-for-legalaid-uat",
+      "offender-case-notes-prod",
+      "whereabouts-api-prod"
       ]
   location: "spec.securityContext.supplementalGroups"
   parameters:


### PR DESCRIPTION
Adding namespaces to exclusion list where stuck terminating pods resides.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6777