### PR TITLE
Upgrading Gatekeeper Version to 3.19.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "gatekeeper" {
   namespace  = kubernetes_namespace.gatekeeper.id
   repository = "https://open-policy-agent.github.io/gatekeeper/charts"
   chart      = "gatekeeper"
-  version    = "3.18.3"
+  version    = "3.19.0"
 
   # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/values.yaml
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {


### PR DESCRIPTION
Previous set version of 3.18.3 had a known DELETE operation bug, causing a null error on each request. Upping to 3.19.0 to fix issue.