### PR TITLE
Remove canary app from namespace constrain exclusions

### DIFF
--- a/resources/constraints/lock_priv_capabilities.yaml
+++ b/resources/constraints/lock_priv_capabilities.yaml
@@ -11,7 +11,6 @@ spec:
       "calico-apiserver",
       "calico-system",
       "cert-manager",
-      "cloud-platform-canary-app-eks",
       "concourse",
       "gatekeeper-system",
       "kuberos",

--- a/resources/constraints/user_ns_requires_psa_label.yaml
+++ b/resources/constraints/user_ns_requires_psa_label.yaml
@@ -24,7 +24,6 @@ spec:
       "smoketest-psp-*",
       "smoketest-psa-*",
       "tigera-operator",
-      "cloud-platform-canary-app-eks",
       "trivy-system",
       "velero"
       ]

--- a/resources/mutations/default_fs_group.yaml
+++ b/resources/mutations/default_fs_group.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.securityContext.fsGroup"
   parameters:

--- a/resources/mutations/default_seccomp_profile.yaml
+++ b/resources/mutations/default_seccomp_profile.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.securityContext.seccompProfile.type"
   parameters:

--- a/resources/mutations/default_supplemental_groups.yaml
+++ b/resources/mutations/default_supplemental_groups.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.securityContext.supplementalGroups"
   parameters:

--- a/resources/mutations/deny_privilege_escalation.yaml
+++ b/resources/mutations/deny_privilege_escalation.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.containers[name:*].securityContext.allowPrivilegeEscalation"
   parameters:

--- a/resources/mutations/deny_privilege_escalation_eph.yaml
+++ b/resources/mutations/deny_privilege_escalation_eph.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.ephemeralContainers[name:*].securityContext.allowPrivilegeEscalation"
   parameters:

--- a/resources/mutations/deny_privilege_escalation_init.yaml
+++ b/resources/mutations/deny_privilege_escalation_init.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.initContainers[name:*].securityContext.allowPrivilegeEscalation"
   parameters:

--- a/resources/mutations/drop_all_cap.yaml
+++ b/resources/mutations/drop_all_cap.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.containers[name:*].securityContext.capabilities.drop"
   parameters:

--- a/resources/mutations/drop_all_cap_eph.yaml
+++ b/resources/mutations/drop_all_cap_eph.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.ephemeralContainers[name:*].securityContext.capabilities.drop"
   parameters:

--- a/resources/mutations/drop_all_cap_init.yaml
+++ b/resources/mutations/drop_all_cap_init.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.initContainers[name:*].securityContext.capabilities.drop"
   parameters:

--- a/resources/mutations/run_as_non_root.yaml
+++ b/resources/mutations/run_as_non_root.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.containers[name:*].securityContext.runAsNonRoot"
   parameters:

--- a/resources/mutations/run_as_non_root_eph.yaml
+++ b/resources/mutations/run_as_non_root_eph.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.ephemeralContainers[name:*].securityContext.runAsNonRoot"
   parameters:

--- a/resources/mutations/run_as_non_root_init.yaml
+++ b/resources/mutations/run_as_non_root_init.yaml
@@ -27,8 +27,7 @@ spec:
       "smoketest-psa-*",
       "tigera-operator",
       "trivy-system",
-      "velero",
-      "cloud-platform-canary-app-eks"
+      "velero"
       ]
   location: "spec.initContainers[name:*].securityContext.runAsNonRoot"
   parameters:


### PR DESCRIPTION
The canary app can run as a regular app and doesn't need any special permissions.