### PR TITLE
Bumped GK Version up to v3.19.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "gatekeeper" {
   namespace  = kubernetes_namespace.gatekeeper.id
   repository = "https://open-policy-agent.github.io/gatekeeper/charts"
   chart      = "gatekeeper"
-  version    = "3.19.0"
+  version    = "3.19.1"
 
   # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/values.yaml
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {


### PR DESCRIPTION
Upgrading Gatekeeper from 3.19.0 to 3.19.1 to fix Gatekeeper resource deletion bug ("Object 'Kind' is missing in ''") occurring in cluster-delete pipeline.