### PR TITLE
feat: 🎸 add ingressClassName constraint

### DIFF
--- a/constraints/locals.tf
+++ b/constraints/locals.tf
@@ -17,6 +17,7 @@ locals {
   warn_kubectl_create_sa                  = yamldecode(file("${path.module}/../resources/constraints/warn_sa.yaml"))
   allow_duplicate_hostname_yaml           = yamldecode(file("${path.module}/../resources/constraints/ingress_allow_duplicate_hostname.yaml"))
   block_ingresses_yaml                    = yamldecode(file("${path.module}/../resources/constraints/block_ingresses.yaml"))
+  ingress_valid_classname_yaml            = yamldecode(file("${path.module}/../resources/constraints/ingress_valid_classname.yaml"))
 
   # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints. -- we merge in the spec separately to avoid overwriting entire spec key
   constraint_map = {
@@ -38,5 +39,6 @@ locals {
     warn_kubectl_create_sa             = merge(local.warn_kubectl_create_sa, { "spec" : merge(local.warn_kubectl_create_sa["spec"], { "enforcementAction" : var.dryrun_map.warn_kubectl_create_sa ? "dryrun" : "warn" }) })
     allow_duplicate_hostname_yaml      = merge(local.allow_duplicate_hostname_yaml, { "spec" : merge(local.allow_duplicate_hostname_yaml["spec"], { "enforcementAction" : var.dryrun_map.allow_duplicate_hostname_yaml ? "dryrun" : "deny" }) })
     block_ingresses_yaml               = merge(local.block_ingresses_yaml, { "spec" : merge(local.block_ingresses_yaml["spec"], { "enforcementAction" : var.dryrun_map.block_ingresses ? "dryrun" : "deny" }) })
+    ingress_valid_classname            = merge(local.ingress_valid_classname_yaml, { "spec" : merge(local.ingress_valid_classname_yaml["spec"], { "enforcementAction" : var.dryrun_map.ingress_valid_classname ? "dryrun" : "deny" }) })
   }
 }

--- a/constraints/variables.tf
+++ b/constraints/variables.tf
@@ -34,6 +34,7 @@ variable "dryrun_map" {
     warn_kubectl_create_sa             = bool
     allow_duplicate_hostname_yaml      = bool
     block_ingresses                    = bool
+    ingress_valid_classname            = bool
   })
 }
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -22,6 +22,7 @@ module "gatekeeper" {
     warn_kubectl_create_sa             = true,
     allow_duplicate_hostname_yaml      = true,
     block_ingresses                    = false,
+    ingress_valid_classname            = true,
   }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25

--- a/resources/constraint_templates/ingress_valid_classname.yaml
+++ b/resources/constraint_templates/ingress_valid_classname.yaml
@@ -1,0 +1,36 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8singressclassname
+  annotations:
+    metadata.gatekeeper.sh/title: Ensure ingressClassName is valid
+    description: |
+        This policy denies any Ingress resources that do not specify an ingressClassName or specify an invalid one.
+
+        The allowed ingress class names can be configured via the 'allowedIngressClasses' parameter in the Constraint.
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8singressclassname
+      validation:
+        openAPIV3Schema:
+          properties:
+            allowedIngressClasses:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8singressclassname
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Ingress"
+          not ingress_class_allowed
+          msg := sprintf("IngressClassName '%s' is not allowed. Allowed values: %v", [input.review.object.spec.ingressClassName, input.parameters.allowedIngressClasses])
+        }
+
+        ingress_class_allowed {
+          input.review.object.spec.ingressClassName == input.parameters.allowedIngressClasses[_]
+        }

--- a/resources/constraints/ingress_valid_classname.yaml
+++ b/resources/constraints/ingress_valid_classname.yaml
@@ -1,0 +1,18 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8singressclassname
+metadata:
+  name: k8singressclassname
+spec:
+  match:
+    kinds:
+      - kinds: ["Ingress"]
+        apiGroups: ["extensions", "networking.k8s.io"]
+  parameters:
+    allowedIngressClasses:
+        - default
+        - default-non-prod
+        - modsec
+        - modsec-non-prod
+        - internal
+        - internal-non-prod
+        - internal-laa

--- a/test/suite/ingress_valid_classname.yaml
+++ b/test/suite/ingress_valid_classname.yaml
@@ -1,0 +1,39 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+- name: classname_valid
+  template: ../../resources/constraint_templates/ingress_valid_classname.yaml
+  constraint: ../../resources/constraints/ingress_valid_classname.yaml
+  cases:
+  - name: allow-classname-default
+    object: samples/ingress_valid_classname/allow_classname/case_default.yaml
+    assertions:
+    - violations: no
+  - name: allow-classname-default-non-prod
+    object: samples/ingress_valid_classname/allow_classname/case_default-non-prod.yaml
+    assertions:
+    - violations: no
+  - name: allow-classname-internal
+    object: samples/ingress_valid_classname/allow_classname/case_internal.yaml
+    assertions:
+    - violations: no
+  - name: allow-classname-internal-laa
+    object: samples/ingress_valid_classname/allow_classname/case_internal-laa.yaml
+    assertions:
+    - violations: no
+  - name: allow-classname-modsec
+    object: samples/ingress_valid_classname/allow_classname/case_modsec.yaml
+    assertions:
+    - violations: no
+  - name: allow-classname-modsec-non-prod
+    object: samples/ingress_valid_classname/allow_classname/case_modsec-non-prod.yaml
+    assertions:
+    - violations: no
+  - name: deny-classname-invalid
+    object: samples/ingress_valid_classname/deny_classname/case.yaml
+    assertions:
+    - violations: yes
+  - name: deny-update-classname-invalid
+    object: samples/ingress_valid_classname/deny_update_classname/case.yaml
+    assertions:
+    - violations: yes

--- a/test/suite/samples/ingress_valid_classname/allow_classname/case_default-non-prod.yaml
+++ b/test/suite/samples/ingress_valid_classname/allow_classname/case_default-non-prod.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "CREATE"
+  name: ing-default-non-prod
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-default-non-prod
+      namespace: default-0
+    spec:
+      ingressClassName: default-non-prod
+      rules:
+      - host: ing-2.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/ingress_valid_classname/allow_classname/case_default.yaml
+++ b/test/suite/samples/ingress_valid_classname/allow_classname/case_default.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "CREATE"
+  name: ing-default
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-default
+      namespace: default-0
+    spec:
+      ingressClassName: default
+      rules:
+      - host: ing-1.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/ingress_valid_classname/allow_classname/case_internal-laa.yaml
+++ b/test/suite/samples/ingress_valid_classname/allow_classname/case_internal-laa.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "CREATE"
+  name: ing-internal-laa
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-internal-laa
+      namespace: default-0
+    spec:
+      ingressClassName: internal-laa
+      rules:
+      - host: ing-6.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/ingress_valid_classname/allow_classname/case_internal.yaml
+++ b/test/suite/samples/ingress_valid_classname/allow_classname/case_internal.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "CREATE"
+  name: ing-internal
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-internal
+      namespace: default-0
+    spec:
+      ingressClassName: internal
+      rules:
+      - host: ing-5.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/ingress_valid_classname/allow_classname/case_modsec-non-prod.yaml
+++ b/test/suite/samples/ingress_valid_classname/allow_classname/case_modsec-non-prod.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "CREATE"
+  name: ing-modsec-non-prod
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-modsec-non-prod
+      namespace: default-0
+    spec:
+      ingressClassName: modsec-non-prod
+      rules:
+      - host: ing-4.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/ingress_valid_classname/allow_classname/case_modsec.yaml
+++ b/test/suite/samples/ingress_valid_classname/allow_classname/case_modsec.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "CREATE"
+  name: ing-modsec
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-modsec
+      namespace: default-0
+    spec:
+      ingressClassName: modsec
+      rules:
+      - host: ing-3.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/ingress_valid_classname/deny_classname/case.yaml
+++ b/test/suite/samples/ingress_valid_classname/deny_classname/case.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "CREATE"
+  name: ing-invalid
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-invalid
+      namespace: default-0
+    spec:
+      ingressClassName: bad-classname
+      rules:
+      - host: ing-0.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/ingress_valid_classname/deny_update_classname/case.yaml
+++ b/test/suite/samples/ingress_valid_classname/deny_update_classname/case.yaml
@@ -1,0 +1,29 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  operation: "UPDATE"
+  name: ing-invalid
+  namespace: default-0
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-invalid
+      namespace: default-0
+    spec:
+      ingressClassName: bad-classname
+      rules:
+      - host: ing-0.example.com
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -26,6 +26,7 @@ module "gatekeeper" {
     warn_kubectl_create_sa             = true,
     allow_duplicate_hostname_yaml      = true,
     block_ingresses                    = false,
+    ingress_valid_classname            = true,
   }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,7 @@ variable "dryrun_map" {
     warn_kubectl_create_sa             = bool
     allow_duplicate_hostname_yaml      = bool
     block_ingresses                    = bool
+    ingress_valid_classname            = bool
   })
 }
 


### PR DESCRIPTION
## Purpose

This PR defines an `ingressClassname` validating policy. We have several classes of ingress controller available on the cluster and this has caused some confusion recently, with typos/misnaming causing bad ingress resources to be created.

The new constraint & template combine to ensure that only ingress objects referencing valid classnames are admitted.

`gator` test suites and cases have also been defined (also see GH actions unit test report)