### PR TITLE
feat: 🎸 add internal valid hostname policy and tests

### DIFF
--- a/constraints/locals.tf
+++ b/constraints/locals.tf
@@ -18,6 +18,7 @@ locals {
   allow_duplicate_hostname_yaml           = yamldecode(file("${path.module}/../resources/constraints/ingress_allow_duplicate_hostname.yaml"))
   block_ingresses_yaml                    = yamldecode(file("${path.module}/../resources/constraints/block_ingresses.yaml"))
   ingress_valid_classname_yaml            = yamldecode(file("${path.module}/../resources/constraints/ingress_valid_classname.yaml"))
+  ingress_internal_class_domain_yaml      = yamldecode(file("${path.module}/../resources/constraints/ingress_internal_class_domain.yaml"))
 
   # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints. -- we merge in the spec separately to avoid overwriting entire spec key
   constraint_map = {
@@ -40,5 +41,6 @@ locals {
     allow_duplicate_hostname_yaml      = merge(local.allow_duplicate_hostname_yaml, { "spec" : merge(local.allow_duplicate_hostname_yaml["spec"], { "enforcementAction" : var.dryrun_map.allow_duplicate_hostname_yaml ? "dryrun" : "deny" }) })
     block_ingresses_yaml               = merge(local.block_ingresses_yaml, { "spec" : merge(local.block_ingresses_yaml["spec"], { "enforcementAction" : var.dryrun_map.block_ingresses ? "dryrun" : "deny" }) })
     ingress_valid_classname            = merge(local.ingress_valid_classname_yaml, { "spec" : merge(local.ingress_valid_classname_yaml["spec"], { "enforcementAction" : var.dryrun_map.ingress_valid_classname ? "dryrun" : "deny" }) })
+    ingress_internal_class_domain       = merge(local.ingress_internal_class_domain_yaml, { "spec" : merge(local.ingress_internal_class_domain_yaml["spec"], { "enforcementAction" : var.dryrun_map.ingress_internal_class_domain ? "dryrun" : "deny", "parameters" : { "validInternalDomains" : ["*.internal.cloud-platform.justice.service.gov.uk"], "validInternalDevDomains" : ["*.internal-dev.cloud-platform.justice.service.gov.uk"] } }) })
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -23,6 +23,7 @@ module "gatekeeper" {
     allow_duplicate_hostname_yaml      = true,
     block_ingresses                    = false,
     ingress_valid_classname            = true,
+    ingress_internal_class_domain      = true,
   }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25

--- a/resources/constraint_templates/ingress_internal_class_domain.yaml
+++ b/resources/constraint_templates/ingress_internal_class_domain.yaml
@@ -1,0 +1,57 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8singressinternalclassdomain
+spec:
+  crd:
+    spec:
+      names:
+        kind: k8singressinternalclassdomain
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            validDomainNames:
+              type: array
+              items:
+                type: string
+            validInternalDomains:
+              type: array
+              items:
+                type: string
+            validInternalDevDomains:
+              type: array
+              items:
+                type: string
+  targets:
+      - target: admission.k8s.gatekeeper.sh
+        rego: |
+          package k8singressinternalclassdomain
+
+          valid_internal_domain {
+            pattern := input.parameters.validInternalDomains[_]
+            host := input.review.object.spec.rules[0].host
+            glob.match(pattern, [], host)
+          }
+
+          valid_internal_dev_domain {
+            pattern := input.parameters.validInternalDevDomains[_]
+            host := input.review.object.spec.rules[0].host
+            glob.match(pattern, [], host)
+          }
+
+          violation[{"msg": msg}] {
+            input.review.kind.kind == "Ingress"
+            input.review.object.spec.ingressClassName == "internal"
+            not valid_internal_domain
+            host := input.review.object.spec.rules[0].host
+            msg := sprintf("Ingress with ingressClassName '%v' must use domain matching one of %v. Found domain: %v", [input.review.object.spec.ingressClassName, input.parameters.validInternalDomains, host])
+          }
+
+          violation[{"msg": msg}] {
+            input.review.kind.kind == "Ingress"
+            input.review.object.spec.ingressClassName == "internal-dev"
+            not valid_internal_dev_domain
+            host := input.review.object.spec.rules[0].host
+            msg := sprintf("Ingress with ingressClassName '%v' must use domain matching one of %v. Found domain: %v", [input.review.object.spec.ingressClassName, input.parameters.validInternalDevDomains, host])
+          }

--- a/resources/constraints/internal_ingress_class_domain.yaml
+++ b/resources/constraints/internal_ingress_class_domain.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: k8singressinternalclassdomain
+metadata:
+  name: internal-ingress-domain
+spec:
+  enforcementAction: deny
+  parameters:
+    validInternalDomains:
+      - "*.internal.cloud-platform.service.justice.gov.uk"
+    validInternalDevDomains:
+      - "*.internal-dev.cloud-platform.service.justice.gov.uk"

--- a/test/suite/internal_ingress_class_domain.yaml
+++ b/test/suite/internal_ingress_class_domain.yaml
@@ -1,0 +1,23 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+- name: internal_ingress_class_domain
+  template: ../../resources/constraint_templates/ingress_internal_class_domain.yaml
+  constraint: ../../resources/constraints/internal_ingress_class_domain.yaml
+  cases:
+  - name: allow-internal-domain
+    object: samples/internal_ingress_class_domain/allow_internal_domain/case.yaml
+    assertions:
+    - violations: no
+  - name: allow-internal-dev-domain
+    object: samples/internal_ingress_class_domain/allow_internal_dev_domain/case.yaml
+    assertions:
+    - violations: no
+  - name: deny-external-domain
+    object: samples/internal_ingress_class_domain/deny_invalid_internal_domain/case.yaml
+    assertions:
+    - violations: yes
+  - name: deny-update-to-external-domain
+    object: samples/internal_ingress_class_domain/deny_invalid_update_to_internal_domain/case.yaml
+    assertions:
+    - violations: yes

--- a/test/suite/samples/internal_ingress_class_domain/allow_internal_dev_domain/case.yaml
+++ b/test/suite/samples/internal_ingress_class_domain/allow_internal_dev_domain/case.yaml
@@ -1,0 +1,33 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+
+  operation: "CREATE"
+
+  name: ing-0
+
+  namespace: default-0
+
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-0
+      namespace: default-0
+    spec:
+      ingressClassName: internal-dev
+      rules:
+      - host: ing-1.internal-dev.cloud-platform.service.justice.gov.uk
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/internal_ingress_class_domain/allow_internal_domain/case.yaml
+++ b/test/suite/samples/internal_ingress_class_domain/allow_internal_domain/case.yaml
@@ -1,0 +1,33 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+
+  operation: "CREATE"
+
+  name: ing-0
+
+  namespace: default-0
+
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-0
+      namespace: default-0
+    spec:
+      ingressClassName: internal
+      rules:
+      - host: ing-1.internal.cloud-platform.service.justice.gov.uk
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/internal_ingress_class_domain/deny_invalid_internal_domain/case.yaml
+++ b/test/suite/samples/internal_ingress_class_domain/deny_invalid_internal_domain/case.yaml
@@ -1,0 +1,33 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+
+  operation: "CREATE"
+
+  name: ing-0
+
+  namespace: default-0
+
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-0
+      namespace: default-0
+    spec:
+      ingressClassName: internal
+      rules:
+      - host: ing-1.invalid-internal.cloud-platform.service.justice.gov.uk
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/suite/samples/internal_ingress_class_domain/deny_invalid_update_to_internal_domain/case.yaml
+++ b/test/suite/samples/internal_ingress_class_domain/deny_invalid_update_to_internal_domain/case.yaml
@@ -1,0 +1,33 @@
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+
+  operation: "UPDATE"
+
+  name: ing-0
+
+  namespace: default-0
+
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ing-0
+      namespace: default-0
+    spec:
+      ingressClassName: internal
+      rules:
+      - host: ing-1.invalid-internal.cloud-platform.service.justice.gov.uk
+        http:
+          paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -27,6 +27,7 @@ module "gatekeeper" {
     allow_duplicate_hostname_yaml      = true,
     block_ingresses                    = false,
     ingress_valid_classname            = true,
+    ingress_internal_class_domain      = true,
   }
   cluster_color                        = "green"
   constraint_violations_max_to_display = 25

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,7 @@ variable "dryrun_map" {
     allow_duplicate_hostname_yaml      = bool
     block_ingresses                    = bool
     ingress_valid_classname            = bool
+    ingress_internal_class_domain      = bool
   })
 }
 


### PR DESCRIPTION
## Purpose

This constraint and template ensures that validation is carried out against Ingress resources of `ingressClassName` types `internal` and `internal-dev`.

Each of these classes have dedicated R53 hosted zones, and we want to enforce platform users to only be able to create hostname records within these zones:

```
internal.cloud-platform.service.justice.gov.uk
internal-dev.cloud-platform.service.justice.gov.uk
```

These new policies provide this enforcement and return appropriate messaging in the case that invalid Ingress resources are attempted to be applied on the cluster.

relates to ministryofjustice/cloud-platform#7594